### PR TITLE
ci(sync): allow manual awesome-unraid sync

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,16 @@ on:
         required: false
         default: false
         type: boolean
+      publish_images:
+        description: "Publish images to GHCR/Docker Hub"
+        required: false
+        default: false
+        type: boolean
+      sync_awesome_unraid:
+        description: "Open or refresh the awesome-unraid sync pull request"
+        required: false
+        default: false
+        type: boolean
       aio_track_override:
         description: "Optional package line override (example: aio-v3)"
         required: false
@@ -71,11 +81,13 @@ jobs:
           GITHUB_SHA_VALUE: ${{ github.sha }}
           GITHUB_REF_VALUE: ${{ github.ref }}
           RUN_SMOKE_TEST_INPUT: ${{ github.event.inputs.run_smoke_test || '' }}
+          PUBLISH_IMAGES_INPUT: ${{ github.event.inputs.publish_images || '' }}
         run: |
           python3 scripts/ci_flags.py \
             --event-name "${EVENT_NAME}" \
             --ref "${GITHUB_REF_VALUE}" \
-            --run-smoke-test-input "${RUN_SMOKE_TEST_INPUT}" >> "${GITHUB_OUTPUT}"
+            --run-smoke-test-input "${RUN_SMOKE_TEST_INPUT}" \
+            --publish-images-input "${PUBLISH_IMAGES_INPUT}" >> "${GITHUB_OUTPUT}"
 
           if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
             echo "build_related=true" >> "${GITHUB_OUTPUT}"
@@ -418,7 +430,7 @@ jobs:
             io.jsonbored.wrapper.track=${{ steps.prep.outputs.aio_track }}
 
   sync-awesome-unraid:
-    if: ${{ needs.detect-changes.outputs.xml_related == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    if: ${{ needs.detect-changes.outputs.xml_related == 'true' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.sync_awesome_unraid == 'true')) }}
     needs:
       - detect-changes
       - validate-template

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,6 +195,7 @@ jobs:
           gh workflow run "CI / SimpleLogin-AIO" \
             --ref main \
             -f run_smoke_test=false \
+            -f publish_images=true \
             -f aio_track_override="${aio_track}"
           echo "Triggered CI / SimpleLogin-AIO workflow_dispatch on main with aio_track_override=${aio_track}."
 
@@ -417,5 +418,6 @@ jobs:
           gh workflow run "CI / SimpleLogin-AIO" \
             --ref main \
             -f run_smoke_test=false \
+            -f publish_images=true \
             -f aio_track_override="${aio_track}"
           echo "Triggered CI / SimpleLogin-AIO workflow_dispatch on main with aio_track_override=${aio_track}."

--- a/scripts/ci_flags.py
+++ b/scripts/ci_flags.py
@@ -24,6 +24,7 @@ def resolve_flags(
     event_name: str,
     ref: str,
     run_smoke_test_input: str | None = None,
+    publish_images_input: str | None = None,
 ) -> CiFlags:
     if event_name == "push" and ref == "refs/heads/main":
         return CiFlags(run_smoke_requested=True, publish_requested=True)
@@ -31,7 +32,7 @@ def resolve_flags(
     if event_name == "workflow_dispatch" and ref == "refs/heads/main":
         return CiFlags(
             run_smoke_requested=parse_bool(run_smoke_test_input),
-            publish_requested=True,
+            publish_requested=parse_bool(publish_images_input),
         )
 
     return CiFlags(run_smoke_requested=False, publish_requested=False)
@@ -42,12 +43,14 @@ def main() -> int:
     parser.add_argument("--event-name", required=True)
     parser.add_argument("--ref", required=True)
     parser.add_argument("--run-smoke-test-input", default="")
+    parser.add_argument("--publish-images-input", default="")
     args = parser.parse_args()
 
     flags = resolve_flags(
         event_name=args.event_name,
         ref=args.ref,
         run_smoke_test_input=args.run_smoke_test_input,
+        publish_images_input=args.publish_images_input,
     )
     print(f"run_smoke_requested={'true' if flags.run_smoke_requested else 'false'}")
     print(f"publish_requested={'true' if flags.publish_requested else 'false'}")

--- a/scripts/test-ci-flags.py
+++ b/scripts/test-ci-flags.py
@@ -6,22 +6,24 @@ from ci_flags import resolve_flags
 
 def main() -> int:
     cases = [
-        ("push", "refs/heads/main", "", True, True),
-        ("push", "refs/heads/feature", "", False, False),
-        ("workflow_dispatch", "refs/heads/main", "true", True, True),
-        ("workflow_dispatch", "refs/heads/main", "1", True, True),
-        ("workflow_dispatch", "refs/heads/main", "false", False, True),
-        ("workflow_dispatch", "refs/heads/main", "", False, True),
-        ("workflow_dispatch", "refs/heads/feature", "true", False, False),
-        ("pull_request", "refs/pull/1/merge", "", False, False),
+        ("push", "refs/heads/main", "", "", True, True),
+        ("push", "refs/heads/feature", "", "", False, False),
+        ("workflow_dispatch", "refs/heads/main", "true", "true", True, True),
+        ("workflow_dispatch", "refs/heads/main", "1", "1", True, True),
+        ("workflow_dispatch", "refs/heads/main", "false", "true", False, True),
+        ("workflow_dispatch", "refs/heads/main", "", "false", False, False),
+        ("workflow_dispatch", "refs/heads/main", "true", "", True, False),
+        ("workflow_dispatch", "refs/heads/feature", "true", "true", False, False),
+        ("pull_request", "refs/pull/1/merge", "", "", False, False),
     ]
 
     for idx, case in enumerate(cases, start=1):
-        event_name, ref, smoke_input, expected_smoke, expected_publish = case
+        event_name, ref, smoke_input, publish_input, expected_smoke, expected_publish = case
         result = resolve_flags(
             event_name=event_name,
             ref=ref,
             run_smoke_test_input=smoke_input,
+            publish_images_input=publish_input,
         )
         assert result.run_smoke_requested == expected_smoke, (
             f"case #{idx} expected run_smoke_requested={expected_smoke}, "


### PR DESCRIPTION
## Summary
- allow the `CI / SimpleLogin-AIO` workflow to open or refresh the `awesome-unraid` sync PR from `workflow_dispatch`
- keep manual image publishing opt-in instead of automatic on every manual run

## What changed
- added `sync_awesome_unraid` workflow input to `build.yml`
- added `publish_images` workflow input to `build.yml`
- updated the sync job condition so it can run from `push` on `main` or from manual dispatch when `sync_awesome_unraid=true`
- updated `scripts/ci_flags.py` so manual runs only publish images when explicitly requested
- updated `scripts/test-ci-flags.py` to cover the new manual-run behavior
- updated `release.yml` to pass `publish_images=true` when release automation dispatches the CI workflow

## Why
- the `awesome-unraid` sync could previously only happen on a successful `push` run to `main`
- if that push run was blocked, cancelled, or skipped, there was no clean way to trigger sync without making another commit
- manual runs were also implicitly publishing images, which was too broad for a sync-only action

## Validation
- `python3 scripts/test-ci-flags.py`
- `python3 -m py_compile scripts/ci_flags.py scripts/test-ci-flags.py`

## Notes
- after merge, you can run `CI / SimpleLogin-AIO` manually on `main` with:
  - `sync_awesome_unraid=true`
  - `publish_images=false`
  - `run_smoke_test=false`
- release-driven workflow dispatches still publish images because `release.yml` now passes `publish_images=true`
