### PR TITLE
docs(template): improve CA metadata and manual sync flow

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,4 @@
 github:
   - JSONbored
 ko_fi: jsonbored
+buy_me_a_coffee: jsonbored

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Local validation is built around:
 If this work saves you time, support it here:
 
 - [GitHub Sponsors](https://github.com/sponsors/JSONbored)
+- [Ko-fi](https://ko-fi.com/jsonbored)
+- [Buy Me a Coffee](https://buymeacoffee.com/jsonbored)
 
 ## Star History
 

--- a/simplelogin-aio.xml
+++ b/simplelogin-aio.xml
@@ -62,8 +62,8 @@ Full changelog and release notes: [url=https://github.com/JSONbored/simplelogin-
   <PostArgs/>
   <CPUset/>
   <DateInstalled/>
-  <DonateText/>
-  <DonateLink/>
+  <DonateText>Support JSONbored on GitHub Sponsors.</DonateText>
+  <DonateLink>https://github.com/sponsors/JSONbored</DonateLink>
   <Description/>
 
   <Networking>

--- a/simplelogin-aio.xml
+++ b/simplelogin-aio.xml
@@ -87,15 +87,15 @@ Full changelog and release notes: [url=https://github.com/JSONbored/simplelogin-
   <Config Name="Custom Assets Directory" Target="/custom-assets" Default="" Mode="rw" Description="Optional host path mounted at /custom-assets for advanced file-based settings such as custom words lists, OpenID keys, Paddle public keys, or imported PGP material." Type="Path" Display="advanced" Required="false" Mask="false"/>
 
   <!-- Core ports -->
-  <Config Name="Web UI Port" Target="7777" Default="7777" Mode="tcp" Description="SimpleLogin web UI port." Type="Port" Display="always" Required="true" Mask="false">7777</Config>
+  <Config Name="Web UI Port" Target="7777" Default="7777" Mode="tcp" Description="Port used by the SimpleLogin web UI." Type="Port" Display="always" Required="true" Mask="false">7777</Config>
   <Config Name="SMTP Inbound Port" Target="25" Default="25" Mode="tcp" Description="Inbound SMTP port. Forward TCP 25 from your router or firewall to the Unraid host if you want aliases to receive internet mail." Type="Port" Display="always" Required="true" Mask="false">25</Config>
 
   <!-- Core required -->
-  <Config Name="App URL" Target="URL" Default="https://app.example.com" Mode="" Description="Public URL for the SimpleLogin dashboard." Type="Variable" Display="always" Required="true" Mask="false"/>
-  <Config Name="Primary Email Domain" Target="EMAIL_DOMAIN" Default="example.com" Mode="" Description="Primary domain used to create aliases." Type="Variable" Display="always" Required="true" Mask="false"/>
-  <Config Name="Support Email" Target="SUPPORT_EMAIL" Default="support@example.com" Mode="" Description="Transactional system email sender address." Type="Variable" Display="always" Required="true" Mask="false"/>
-  <Config Name="Flask Secret" Target="FLASK_SECRET" Default="" Mode="" Description="Long random secret used for Flask sessions and application security." Type="Variable" Display="always" Required="true" Mask="true"/>
-  <Config Name="SMTP Relay Mode" Target="RELAY_MODE" Default="direct" Mode="" Description="Wrapper-level outbound relay mode. Use a relay provider if your ISP blocks outbound port 25." Type="Variable" Display="always" Required="true" Mask="false">
+  <Config Name="App URL" Target="URL" Default="https://app.example.com" Mode="" Description="Public HTTPS URL for the dashboard, for example https://mail.example.com." Type="Variable" Display="always" Required="true" Mask="false"/>
+  <Config Name="Primary Email Domain" Target="EMAIL_DOMAIN" Default="example.com" Mode="" Description="Primary alias domain, for example example.com." Type="Variable" Display="always" Required="true" Mask="false"/>
+  <Config Name="Support Email" Target="SUPPORT_EMAIL" Default="support@example.com" Mode="" Description="From address for system mail, for example support@example.com." Type="Variable" Display="always" Required="true" Mask="false"/>
+  <Config Name="Flask Secret" Target="FLASK_SECRET" Default="" Mode="" Description="Long random app secret. Generate with: openssl rand -hex 32" Type="Variable" Display="always" Required="true" Mask="true"/>
+  <Config Name="SMTP Relay Mode" Target="RELAY_MODE" Default="direct" Mode="" Description="Outbound mail mode. Use a relay provider if your ISP blocks outbound TCP 25." Type="Variable" Display="always" Required="true" Mask="false">
     <Option Value="direct">Direct Delivery</Option>
     <Option Value="brevo">Brevo</Option>
     <Option Value="protonmail">Proton Mail SMTP Token</Option>
@@ -105,28 +105,28 @@ Full changelog and release notes: [url=https://github.com/JSONbored/simplelogin-
   </Config>
 
   <!-- Relay credentials -->
-  <Config Name="Brevo Username" Target="BREVO_USERNAME" Default="" Mode="" Description="Required when RELAY_MODE=brevo." Type="Variable" Display="advanced" Required="false" Mask="true"/>
-  <Config Name="Brevo Password" Target="BREVO_PASSWORD" Default="" Mode="" Description="Required when RELAY_MODE=brevo." Type="Variable" Display="advanced" Required="false" Mask="true"/>
-  <Config Name="Proton Mail SMTP Token" Target="PROTONMAIL_TOKEN" Default="" Mode="" Description="Required when RELAY_MODE=protonmail." Type="Variable" Display="advanced" Required="false" Mask="true"/>
-  <Config Name="Gmail Username" Target="GMAIL_USERNAME" Default="" Mode="" Description="Required when RELAY_MODE=gmail." Type="Variable" Display="advanced" Required="false" Mask="true"/>
-  <Config Name="Gmail App Password" Target="GMAIL_APP_PASSWORD" Default="" Mode="" Description="Required when RELAY_MODE=gmail." Type="Variable" Display="advanced" Required="false" Mask="true"/>
-  <Config Name="Mailgun Username" Target="MAILGUN_USERNAME" Default="" Mode="" Description="Required when RELAY_MODE=mailgun." Type="Variable" Display="advanced" Required="false" Mask="true"/>
-  <Config Name="Mailgun Password" Target="MAILGUN_PASSWORD" Default="" Mode="" Description="Required when RELAY_MODE=mailgun." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="Brevo Username" Target="BREVO_USERNAME" Default="" Mode="" Description="Brevo SMTP username, usually your account email. Required when RELAY_MODE=brevo." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="Brevo Password" Target="BREVO_PASSWORD" Default="" Mode="" Description="Brevo SMTP key or password. Required when RELAY_MODE=brevo." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="Proton Mail SMTP Token" Target="PROTONMAIL_TOKEN" Default="" Mode="" Description="Proton Mail Bridge SMTP token. Required when RELAY_MODE=protonmail." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="Gmail Username" Target="GMAIL_USERNAME" Default="" Mode="" Description="Full Gmail address used for relay auth. Required when RELAY_MODE=gmail." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="Gmail App Password" Target="GMAIL_APP_PASSWORD" Default="" Mode="" Description="16-character Gmail app password. Required when RELAY_MODE=gmail." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="Mailgun Username" Target="MAILGUN_USERNAME" Default="" Mode="" Description="Mailgun SMTP username, usually postmaster@yourdomain. Required when RELAY_MODE=mailgun." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="Mailgun Password" Target="MAILGUN_PASSWORD" Default="" Mode="" Description="Mailgun SMTP password. Required when RELAY_MODE=mailgun." Type="Variable" Display="advanced" Required="false" Mask="true"/>
   <Config Name="Custom Relay Host" Target="CUSTOM_RELAYHOST" Default="" Mode="" Description="Required when RELAY_MODE=custom. Example: [smtp.provider.com]:587" Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Custom Relay Username" Target="CUSTOM_USERNAME" Default="" Mode="" Description="Required when RELAY_MODE=custom." Type="Variable" Display="advanced" Required="false" Mask="true"/>
-  <Config Name="Custom Relay Password" Target="CUSTOM_PASSWORD" Default="" Mode="" Description="Required when RELAY_MODE=custom." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="Custom Relay Username" Target="CUSTOM_USERNAME" Default="" Mode="" Description="SMTP username for your custom relay. Required when RELAY_MODE=custom." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="Custom Relay Password" Target="CUSTOM_PASSWORD" Default="" Mode="" Description="SMTP password for your custom relay. Required when RELAY_MODE=custom." Type="Variable" Display="advanced" Required="false" Mask="true"/>
 
   <!-- AIO core overrides -->
-  <Config Name="External PostgreSQL DB_URI" Target="DB_URI" Default="" Mode="" Description="Leave blank to use the internal PostgreSQL instance. Set a full postgresql:// connection string to use an external database." Type="Variable" Display="advanced" Required="false" Mask="true"/>
-  <Config Name="External Redis URL" Target="REDIS_URL" Default="" Mode="" Description="Leave blank to use the internal Redis instance. Set a full redis:// URL to use an external Redis service." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="External PostgreSQL DB_URI" Target="DB_URI" Default="" Mode="" Description="Leave blank for the bundled database. External format: postgresql://user:pass@host:5432/dbname" Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="External Redis URL" Target="REDIS_URL" Default="" Mode="" Description="Leave blank for the bundled Redis. External format: redis://:pass@host:6379/0" Type="Variable" Display="advanced" Required="false" Mask="true"/>
   <Config Name="Postfix Server Override" Target="POSTFIX_SERVER" Default="127.0.0.1" Mode="" Description="Advanced escape hatch. Leave at 127.0.0.1 to keep the bundled Postfix path." Type="Variable" Display="advanced" Required="false" Mask="false">127.0.0.1</Config>
   <Config Name="Postfix Port Override" Target="POSTFIX_PORT" Default="25" Mode="" Description="Advanced escape hatch. Leave at 25 for the bundled Postfix path." Type="Variable" Display="advanced" Required="false" Mask="false">25</Config>
-  <Config Name="DNS Nameservers" Target="NAMESERVERS" Default="1.1.1.1,1.0.0.1" Mode="" Description="Comma-separated DNS nameservers used by the app for lookups." Type="Variable" Display="advanced" Required="false" Mask="false">1.1.1.1,1.0.0.1</Config>
-  <Config Name="Custom Temp Directory" Target="TEMP_DIR" Default="" Mode="" Description="Optional temporary directory override." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="DNS Nameservers" Target="NAMESERVERS" Default="1.1.1.1,1.0.0.1" Mode="" Description="Comma-separated resolvers used for lookups, for example 1.1.1.1,1.0.0.1." Type="Variable" Display="advanced" Required="false" Mask="false">1.1.1.1,1.0.0.1</Config>
+  <Config Name="Custom Temp Directory" Target="TEMP_DIR" Default="" Mode="" Description="Optional temp directory path inside the container or a mounted path." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Words File Path" Target="WORDS_FILE_PATH" Default="/code/local_data/test_words.txt" Mode="" Description="Advanced path override for the words file used for random alias generation. Use /custom-assets if you mount your own file." Type="Variable" Display="advanced" Required="false" Mask="false">/code/local_data/test_words.txt</Config>
   <Config Name="Local File Uploads" Target="LOCAL_FILE_UPLOAD" Default="true" Mode="" Description="Leave true for local file storage inside /appdata." Type="Variable" Display="advanced" Required="false" Mask="false">true</Config>
   <Config Name="GnuPG Home" Target="GNUPGHOME" Default="/pgp" Mode="" Description="GnuPG home directory path used for PGP features." Type="Variable" Display="advanced" Required="false" Mask="false">/pgp</Config>
-  <Config Name="Partner API Token Secret" Target="PARTNER_API_TOKEN_SECRET" Default="" Mode="" Description="Advanced partner token secret. If left blank, the wrapper falls back to FLASK_SECRET." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="Partner API Token Secret" Target="PARTNER_API_TOKEN_SECRET" Default="" Mode="" Description="Optional partner token secret. Generate with: openssl rand -hex 32. Blank uses FLASK_SECRET." Type="Variable" Display="advanced" Required="false" Mask="true"/>
 
   <!-- Security and registration -->
   <Config Name="Disable Registration" Target="DISABLE_REGISTRATION" Default="1" Mode="" Description="Set to 1 to block public registration after your initial setup." Type="Variable" Display="advanced" Required="false" Mask="false">1</Config>
@@ -139,27 +139,27 @@ Full changelog and release notes: [url=https://github.com/JSONbored/simplelogin-
   <Config Name="Support Name" Target="SUPPORT_NAME" Default="" Mode="" Description="Display name used alongside SUPPORT_EMAIL." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Postmaster Address" Target="POSTMASTER" Default="" Mode="" Description="Postmaster email used by some mail-related features." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Max Free Plan Email Count" Target="MAX_NB_EMAIL_FREE_PLAN" Default="10" Mode="" Description="Max number of emails a non-premium user can generate." Type="Variable" Display="advanced" Required="false" Mask="false">10</Config>
-  <Config Name="Alias Rate Limit" Target="ALIAS_LIMIT" Default="" Mode="" Description="Example: 100/day;50/hour;5/minute" Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Alias Rate Limit" Target="ALIAS_LIMIT" Default="" Mode="" Description="Alias creation rate limit. Example: 100/day;50/hour;5/minute" Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Automatically Disable Aliases" Target="ALIAS_AUTOMATIC_DISABLE" Default="" Mode="" Description="Optional automatic alias disable behavior." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Allowed Redirect Domains" Target="ALLOWED_REDIRECT_DOMAINS" Default="" Mode="" Description="JSON-style list of domains allowed in absolute redirect next= parameters." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Allowed Redirect Domains" Target="ALLOWED_REDIRECT_DOMAINS" Default="" Mode="" Description="JSON list of allowed redirect domains. Example: [&quot;app.example.com&quot;]" Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Landing Page URL" Target="LANDING_PAGE_URL" Default="" Mode="" Description="Optional landing page URL shown by the app." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Status Page URL" Target="STATUS_PAGE_URL" Default="" Mode="" Description="Optional status page URL shown by the app." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="hCaptcha Secret" Target="HCAPTCHA_SECRET" Default="" Mode="" Description="Enable hCaptcha by setting both hCaptcha fields." Type="Variable" Display="advanced" Required="false" Mask="true"/>
-  <Config Name="hCaptcha Site Key" Target="HCAPTCHA_SITEKEY" Default="" Mode="" Description="Enable hCaptcha by setting both hCaptcha fields." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="hCaptcha Secret" Target="HCAPTCHA_SECRET" Default="" Mode="" Description="hCaptcha secret key from your hCaptcha site. Set both hCaptcha fields to enable." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="hCaptcha Site Key" Target="HCAPTCHA_SITEKEY" Default="" Mode="" Description="hCaptcha site key from your hCaptcha site. Set both hCaptcha fields to enable." Type="Variable" Display="advanced" Required="false" Mask="false"/>
 
   <!-- Alias domains and routing -->
-  <Config Name="Email Servers With Priority" Target="EMAIL_SERVERS_WITH_PRIORITY" Default="[(10, &quot;mail.example.com.&quot;)]" Mode="" Description="Python-style list of MX servers custom domains should point to." Type="Variable" Display="advanced" Required="false" Mask="false">[(10, "mail.example.com.")]</Config>
-  <Config Name="Other Alias Domains" Target="OTHER_ALIAS_DOMAINS" Default="" Mode="" Description="JSON-style list of extra alias domains in addition to EMAIL_DOMAIN." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Alias Domains Override" Target="ALIAS_DOMAINS" Default="" Mode="" Description="If set, overrides OTHER_ALIAS_DOMAINS." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Premium Alias Domains" Target="PREMIUM_ALIAS_DOMAINS" Default="" Mode="" Description="JSON-style list of premium-only alias domains." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Email Servers With Priority" Target="EMAIL_SERVERS_WITH_PRIORITY" Default="[(10, &quot;mail.example.com.&quot;)]" Mode="" Description="MX records custom domains should use. Example: [(10, &quot;mail.example.com.&quot;)]" Type="Variable" Display="advanced" Required="false" Mask="false">[(10, "mail.example.com.")]</Config>
+  <Config Name="Other Alias Domains" Target="OTHER_ALIAS_DOMAINS" Default="" Mode="" Description="JSON list of extra alias domains. Example: [&quot;example.net&quot;,&quot;example.org&quot;]" Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Alias Domains Override" Target="ALIAS_DOMAINS" Default="" Mode="" Description="Full alias-domain override as a JSON list. If set, it replaces OTHER_ALIAS_DOMAINS." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Premium Alias Domains" Target="PREMIUM_ALIAS_DOMAINS" Default="" Mode="" Description="JSON list of premium-only domains. Example: [&quot;vip.example.com&quot;]" Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="First Alias Domain" Target="FIRST_ALIAS_DOMAIN" Default="" Mode="" Description="Alias domain used when creating the first alias." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Bounce Prefix" Target="BOUNCE_PREFIX" Default="" Mode="" Description="VERP bounce prefix. Must end with + if used." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Bounce Suffix" Target="BOUNCE_SUFFIX" Default="" Mode="" Description="VERP bounce suffix. Must start with + if used." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Bounce Prefix For Reply Phase" Target="BOUNCE_PREFIX_FOR_REPLY_PHASE" Default="" Mode="" Description="Reply-phase bounce prefix without a trailing +." Type="Variable" Display="advanced" Required="false" Mask="false"/>
 
   <!-- Social and SSO auth -->
-  <Config Name="GitHub Client ID" Target="GITHUB_CLIENT_ID" Default="" Mode="" Description="GitHub OAuth client ID." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="GitHub Client Secret" Target="GITHUB_CLIENT_SECRET" Default="" Mode="" Description="GitHub OAuth client secret." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="GitHub Client ID" Target="GITHUB_CLIENT_ID" Default="" Mode="" Description="GitHub OAuth app client ID." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="GitHub Client Secret" Target="GITHUB_CLIENT_SECRET" Default="" Mode="" Description="GitHub OAuth app client secret." Type="Variable" Display="advanced" Required="false" Mask="true"/>
   <Config Name="Google Client ID" Target="GOOGLE_CLIENT_ID" Default="" Mode="" Description="Google OAuth client ID." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Google Client Secret" Target="GOOGLE_CLIENT_SECRET" Default="" Mode="" Description="Google OAuth client secret." Type="Variable" Display="advanced" Required="false" Mask="true"/>
   <Config Name="Facebook Client ID" Target="FACEBOOK_CLIENT_ID" Default="" Mode="" Description="Facebook OAuth client ID." Type="Variable" Display="advanced" Required="false" Mask="false"/>
@@ -171,16 +171,16 @@ Full changelog and release notes: [url=https://github.com/JSONbored/simplelogin-
   <Config Name="Connect With Proton" Target="CONNECT_WITH_PROTON" Default="" Mode="" Description="Enable Proton login integration." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Proton Cookie Name" Target="CONNECT_WITH_PROTON_COOKIE_NAME" Default="" Mode="" Description="Cookie name for Proton login integration." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="OIDC Icon" Target="CONNECT_WITH_OIDC_ICON" Default="" Mode="" Description="Font Awesome icon slug for generic OIDC login button." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="OIDC Discovery URL" Target="OIDC_WELL_KNOWN_URL" Default="" Mode="" Description="OpenID Connect discovery URL." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="OIDC Scopes" Target="OIDC_SCOPES" Default="openid email profile" Mode="" Description="OIDC scopes." Type="Variable" Display="advanced" Required="false" Mask="false">openid email profile</Config>
+  <Config Name="OIDC Discovery URL" Target="OIDC_WELL_KNOWN_URL" Default="" Mode="" Description="OIDC discovery URL, usually ending in /.well-known/openid-configuration." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="OIDC Scopes" Target="OIDC_SCOPES" Default="openid email profile" Mode="" Description="Space-separated OIDC scopes. Default works for most providers." Type="Variable" Display="advanced" Required="false" Mask="false">openid email profile</Config>
   <Config Name="OIDC Name Field" Target="OIDC_NAME_FIELD" Default="name" Mode="" Description="OIDC user-info field used for display name." Type="Variable" Display="advanced" Required="false" Mask="false">name</Config>
   <Config Name="OIDC Client ID" Target="OIDC_CLIENT_ID" Default="" Mode="" Description="OIDC client ID." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="OIDC Client Secret" Target="OIDC_CLIENT_SECRET" Default="" Mode="" Description="OIDC client secret." Type="Variable" Display="advanced" Required="false" Mask="true"/>
 
   <!-- OpenID provider / JWT -->
   <Config Name="Enable SimpleLogin OIDC Provider" Target="ENABLE_OIDC_SERVER" Default="0" Mode="" Description="Set to 1 to enable SimpleLogin as an OpenID provider." Type="Variable" Display="advanced" Required="false" Mask="false">0</Config>
-  <Config Name="OpenID Private Key Path" Target="OPENID_PRIVATE_KEY_PATH" Default="" Mode="" Description="Optional custom OpenID private key path. The wrapper auto-generates keys if ENABLE_OIDC_SERVER=1 and these are unset." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="OpenID Public Key Path" Target="OPENID_PUBLIC_KEY_PATH" Default="" Mode="" Description="Optional custom OpenID public key path." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="OpenID Private Key Path" Target="OPENID_PRIVATE_KEY_PATH" Default="" Mode="" Description="Optional OpenID private key path. Blank auto-generates when ENABLE_OIDC_SERVER=1." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="OpenID Public Key Path" Target="OPENID_PUBLIC_KEY_PATH" Default="" Mode="" Description="Optional OpenID public key path matching the private key above." Type="Variable" Display="advanced" Required="false" Mask="false"/>
 
   <!-- Apple -->
   <Config Name="Apple API Secret" Target="APPLE_API_SECRET" Default="" Mode="" Description="Apple sign-in API secret." Type="Variable" Display="advanced" Required="false" Mask="true"/>
@@ -198,7 +198,7 @@ Full changelog and release notes: [url=https://github.com/JSONbored/simplelogin-
   <Config Name="Enable SpamAssassin" Target="ENABLE_SPAM_ASSASSIN" Default="0" Mode="" Description="Set to 1 to enable SpamAssassin integration." Type="Variable" Display="advanced" Required="false" Mask="false">0</Config>
   <Config Name="SpamAssassin Host" Target="SPAMASSASSIN_HOST" Default="" Mode="" Description="SpamAssassin server host or IP." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="HIBP Scan Interval Days" Target="HIBP_SCAN_INTERVAL_DAYS" Default="7" Mode="" Description="How often to check Have I Been Pwned data." Type="Variable" Display="advanced" Required="false" Mask="false">7</Config>
-  <Config Name="HIBP API Keys" Target="HIBP_API_KEYS" Default="" Mode="" Description="JSON-style list of Have I Been Pwned API keys." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="HIBP API Keys" Target="HIBP_API_KEYS" Default="" Mode="" Description="JSON list of HIBP API keys. Example: [&quot;key1&quot;,&quot;key2&quot;]" Type="Variable" Display="advanced" Required="false" Mask="true"/>
 
   <!-- PGP and DKIM -->
   <Config Name="Auto-Generate PGP Server Key" Target="AUTO_GENERATE_PGP" Default="0" Mode="" Description="Set to 1 to auto-generate a PGP server key pair." Type="Variable" Display="advanced" Required="false" Mask="false">0</Config>
@@ -207,13 +207,13 @@ Full changelog and release notes: [url=https://github.com/JSONbored/simplelogin-
 
   <!-- AWS / storage / billing -->
   <Config Name="S3 Bucket" Target="BUCKET" Default="" Mode="" Description="Bucket name used by upstream S3-backed features." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="AWS Access Key ID" Target="AWS_ACCESS_KEY_ID" Default="" Mode="" Description="AWS access key ID." Type="Variable" Display="advanced" Required="false" Mask="true"/>
-  <Config Name="AWS Secret Access Key" Target="AWS_SECRET_ACCESS_KEY" Default="" Mode="" Description="AWS secret access key." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="AWS Access Key ID" Target="AWS_ACCESS_KEY_ID" Default="" Mode="" Description="AWS or S3-compatible access key ID." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="AWS Secret Access Key" Target="AWS_SECRET_ACCESS_KEY" Default="" Mode="" Description="AWS or S3-compatible secret access key." Type="Variable" Display="advanced" Required="false" Mask="true"/>
   <Config Name="AWS Region" Target="AWS_REGION" Default="" Mode="" Description="AWS region." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Paddle Vendor ID" Target="PADDLE_VENDOR_ID" Default="" Mode="" Description="Paddle vendor ID." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Paddle Monthly Product ID" Target="PADDLE_MONTHLY_PRODUCT_ID" Default="" Mode="" Description="Paddle monthly product ID." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Paddle Yearly Product ID" Target="PADDLE_YEARLY_PRODUCT_ID" Default="" Mode="" Description="Paddle yearly product ID." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Paddle Public Key Path" Target="PADDLE_PUBLIC_KEY_PATH" Default="" Mode="" Description="Path to the Paddle public key file. Use /custom-assets if you mount your own key." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Paddle Public Key Path" Target="PADDLE_PUBLIC_KEY_PATH" Default="" Mode="" Description="Path to your Paddle public key file, for example /custom-assets/paddle_public.pem." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Paddle Auth Code" Target="PADDLE_AUTH_CODE" Default="" Mode="" Description="Paddle auth code." Type="Variable" Display="advanced" Required="false" Mask="true"/>
   <Config Name="Coinbase Webhook Secret" Target="COINBASE_WEBHOOK_SECRET" Default="" Mode="" Description="Coinbase webhook secret." Type="Variable" Display="advanced" Required="false" Mask="true"/>
   <Config Name="Coinbase Checkout ID" Target="COINBASE_CHECKOUT_ID" Default="" Mode="" Description="Coinbase checkout ID." Type="Variable" Display="advanced" Required="false" Mask="false"/>
@@ -229,8 +229,8 @@ Full changelog and release notes: [url=https://github.com/JSONbored/simplelogin-
   <Config Name="Legacy Free Plan Alias Limit" Target="MAX_NB_EMAIL_OLD_FREE_PLAN" Default="" Mode="" Description="Legacy free-plan alias cap used for old accounts." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="DB Connection Name" Target="DB_CONN_NAME" Default="" Mode="" Description="Optional PostgreSQL application_name override." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="AWS Endpoint URL" Target="AWS_ENDPOINT_URL" Default="" Mode="" Description="Optional custom S3-compatible endpoint URL." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Paddle Monthly Product IDs" Target="PADDLE_MONTHLY_PRODUCT_IDS" Default="" Mode="" Description="JSON-style list of extra Paddle monthly product IDs." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Paddle Yearly Product IDs" Target="PADDLE_YEARLY_PRODUCT_IDS" Default="" Mode="" Description="JSON-style list of extra Paddle yearly product IDs." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Paddle Monthly Product IDs" Target="PADDLE_MONTHLY_PRODUCT_IDS" Default="" Mode="" Description="JSON list of extra Paddle monthly product IDs. Example: [12345,67890]" Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Paddle Yearly Product IDs" Target="PADDLE_YEARLY_PRODUCT_IDS" Default="" Mode="" Description="JSON list of extra Paddle yearly product IDs. Example: [12345,67890]" Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Paddle Coupon ID" Target="PADDLE_COUPON_ID" Default="" Mode="" Description="Optional Paddle coupon product ID." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Proton Extra Header Name" Target="PROTON_EXTRA_HEADER_NAME" Default="" Mode="" Description="Optional Proton integration header name override." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Proton Extra Header Value" Target="PROTON_EXTRA_HEADER_VALUE" Default="" Mode="" Description="Optional Proton integration header value." Type="Variable" Display="advanced" Required="false" Mask="true"/>
@@ -262,10 +262,10 @@ Full changelog and release notes: [url=https://github.com/JSONbored/simplelogin-
   <Config Name="Zendesk Enabled" Target="ZENDESK_ENABLED" Default="false" Mode="" Description="Presence-based upstream flag to enable Zendesk integration." Type="Variable" Display="advanced" Required="false" Mask="false">false</Config>
   <Config Name="DMARC Check Enabled" Target="DMARC_CHECK_ENABLED" Default="false" Mode="" Description="Presence-based upstream flag to enable DMARC checks." Type="Variable" Display="advanced" Required="false" Mask="false">false</Config>
   <Config Name="VERP Prefix" Target="VERP_PREFIX" Default="" Mode="" Description="VERP prefix override." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="VERP Email Secret" Target="VERP_EMAIL_SECRET" Default="" Mode="" Description="Custom VERP email secret. Must be at least 32 characters if set." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="VERP Email Secret" Target="VERP_EMAIL_SECRET" Default="" Mode="" Description="Custom VERP secret. Generate with: openssl rand -hex 32. Must be at least 32 chars." Type="Variable" Display="advanced" Required="false" Mask="true"/>
   <Config Name="Transactional Bounce Prefix" Target="TRANSACTIONAL_BOUNCE_PREFIX" Default="" Mode="" Description="Optional transactional bounce prefix." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Transactional Bounce Suffix" Target="TRANSACTIONAL_BOUNCE_SUFFIX" Default="" Mode="" Description="Optional transactional bounce suffix." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Alias Transfer Token Secret" Target="ALIAS_TRANSFER_TOKEN_SECRET" Default="" Mode="" Description="Custom alias transfer token secret." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="Alias Transfer Token Secret" Target="ALIAS_TRANSFER_TOKEN_SECRET" Default="" Mode="" Description="Alias transfer token secret. Generate with: openssl rand -hex 32" Type="Variable" Display="advanced" Required="false" Mask="true"/>
   <Config Name="Disable Create Contacts For Free Users" Target="DISABLE_CREATE_CONTACTS_FOR_FREE_USERS" Default="" Mode="" Description="Optional upstream behavior override for free-user contact creation." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Alias Random Suffix Length" Target="ALIAS_RAND_SUFFIX_LENGTH" Default="" Mode="" Description="Length of generated alias random suffix." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Event Webhook URL" Target="EVENT_WEBHOOK" Default="" Mode="" Description="Optional event webhook destination URL." Type="Variable" Display="advanced" Required="false" Mask="false"/>
@@ -275,7 +275,7 @@ Full changelog and release notes: [url=https://github.com/JSONbored/simplelogin-
   <Config Name="Event Listener DB URI" Target="EVENT_LISTENER_DB_URI" Default="" Mode="" Description="Optional dedicated DB URI for the event listener." Type="Variable" Display="advanced" Required="false" Mask="true"/>
   <Config Name="Max API Keys" Target="MAX_API_KEYS" Default="" Mode="" Description="Maximum number of API keys per user." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Memory Store URI" Target="MEM_STORE_URI" Default="" Mode="" Description="Optional memory store URI override." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Recovery Code HMAC Secret" Target="RECOVERY_CODE_HMAC_SECRET" Default="" Mode="" Description="Recovery-code HMAC secret. Must be at least 16 characters if set." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="Recovery Code HMAC Secret" Target="RECOVERY_CODE_HMAC_SECRET" Default="" Mode="" Description="Recovery-code HMAC secret. Generate with: openssl rand -hex 32. Must be at least 16 chars." Type="Variable" Display="advanced" Required="false" Mask="true"/>
   <Config Name="Min Rspamd Score For Failed DMARC" Target="MIN_RSPAMD_SCORE_FOR_FAILED_DMARC" Default="" Mode="" Description="Rspamd score threshold for quarantining DMARC-failed email." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Enable All Reverse Alias Replacement" Target="ENABLE_ALL_REVERSE_ALIAS_REPLACEMENT" Default="false" Mode="" Description="Presence-based upstream flag to replace all reverse aliases." Type="Variable" Display="advanced" Required="false" Mask="false">false</Config>
   <Config Name="Max Reverse Alias Replacements" Target="MAX_NB_REVERSE_ALIAS_REPLACEMENT" Default="" Mode="" Description="Maximum reverse aliases replaced when the related feature is enabled." Type="Variable" Display="advanced" Required="false" Mask="false"/>
@@ -286,16 +286,16 @@ Full changelog and release notes: [url=https://github.com/JSONbored/simplelogin-
   <Config Name="Alias Restore All Rate Limit" Target="ALIAS_RESTORE_ALL_RATE_LIMIT" Default="" Mode="" Description="Bulk alias restore rate limits in hits,seconds:hits,seconds format." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Max Bounces Per Day" Target="MAX_BOUNCES_1D" Default="" Mode="" Description="Maximum daily bounces before automatic handling triggers." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Max Bounces Per Week" Target="MAX_BOUNCES_1W" Default="" Mode="" Description="Maximum weekly bounces before automatic handling triggers." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Partner DNS Custom Domains" Target="PARTNER_DNS_CUSTOM_DOMAINS" Default="" Mode="" Description="Expert partner mapping in key=value;key=value format." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Partner Domain Validation Prefixes" Target="PARTNER_CUSTOM_DOMAIN_VALIDATION_PREFIXES" Default="" Mode="" Description="Expert partner validation prefixes in key=value;key=value format." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Partner DNS Custom Domains" Target="PARTNER_DNS_CUSTOM_DOMAINS" Default="" Mode="" Description="Expert partner mapping in key=value;key=value format. Example: a.com=x.com;b.com=y.com" Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Partner Domain Validation Prefixes" Target="PARTNER_CUSTOM_DOMAIN_VALIDATION_PREFIXES" Default="" Mode="" Description="Expert validation prefixes in key=value;key=value format." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Mailbox Verification Override Code" Target="MAILBOX_VERIFICATION_OVERRIDE_CODE" Default="" Mode="" Description="Optional mailbox verification override code for controlled environments." Type="Variable" Display="advanced" Required="false" Mask="true"/>
   <Config Name="Audit Log Max Days" Target="AUDIT_LOG_MAX_DAYS" Default="" Mode="" Description="Maximum audit log retention in days." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Alias Trash Days" Target="ALIAS_TRASH_DAYS" Default="" Mode="" Description="Days before trashed aliases are purged." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Allowed OAuth Schemes" Target="ALLOWED_OAUTH_SCHEMES" Default="" Mode="" Description="Comma-separated allowed OAuth callback schemes." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Max Email Forward Recipients" Target="MAX_EMAIL_FORWARD_RECIPIENTS" Default="" Mode="" Description="Maximum forward recipients per email." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Master Encryption Key Hex" Target="MASTER_ENC_KEY_HEX" Default="" Mode="" Description="Hex-encoded master encryption key override." Type="Variable" Display="advanced" Required="false" Mask="true"/>
-  <Config Name="MAC Key Hex" Target="MAC_KEY_HEX" Default="" Mode="" Description="Hex-encoded MAC key override." Type="Variable" Display="advanced" Required="false" Mask="true"/>
-  <Config Name="Abuser HKDF Salt" Target="ABUSER_HKDF_SALT" Default="" Mode="" Description="Hex-encoded HKDF salt override." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="Master Encryption Key Hex" Target="MASTER_ENC_KEY_HEX" Default="" Mode="" Description="Hex-encoded master encryption key. Generate with: openssl rand -hex 32" Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="MAC Key Hex" Target="MAC_KEY_HEX" Default="" Mode="" Description="Hex-encoded MAC key. Generate with: openssl rand -hex 32" Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="Abuser HKDF Salt" Target="ABUSER_HKDF_SALT" Default="" Mode="" Description="Hex-encoded HKDF salt. Generate with: openssl rand -hex 32" Type="Variable" Display="advanced" Required="false" Mask="true"/>
   <Config Name="Invalid MX IPs" Target="INVALID_MX_IPS" Default="" Mode="" Description="Comma-separated invalid MX IPs ignored by validation logic." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Use Rust PGP" Target="USE_RUST_PGP" Default="false" Mode="" Description="Presence-based upstream flag to use the Rust PGP implementation." Type="Variable" Display="advanced" Required="false" Mask="false">false</Config>
   <Config Name="SMTP Size Limit" Target="SMTP_SIZE_LIMIT" Default="" Mode="" Description="Maximum SMTP message size in bytes." Type="Variable" Display="advanced" Required="false" Mask="false"/>

--- a/simplelogin-aio.xml
+++ b/simplelogin-aio.xml
@@ -52,11 +52,12 @@
 &#xD;
 &#xD;
 Full changelog and release notes: [url=https://github.com/JSONbored/simplelogin-aio/releases]GitHub Releases[/url]</Changes>
-  <Category>Network: Email: Privacy:</Category>
+  <Category>Network:Privacy Network:Web</Category>
   <WebUI>http://[IP]:[PORT:7777]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/simplelogin-aio.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/icons/simplelogin.jpeg</Icon>
   <ExtraSearchTerms>email alias privacy forwarding self-hosted proton mail postfix smtp dkim</ExtraSearchTerms>
+  <Requires>**For full inbound mail delivery:** a public domain, correct DNS records, and inbound TCP 25 forwarded to your Unraid host. If outbound TCP 25 is blocked, use an SMTP relay mode instead of direct delivery.</Requires>
   <ExtraParams/>
   <PostArgs/>
   <CPUset/>


### PR DESCRIPTION
## Summary
- add a clean manual path for syncing `simplelogin-aio.xml` to `awesome-unraid`
- improve Unraid template clarity, CA metadata, funding links, and donation metadata

## What changed
- added manual `workflow_dispatch` support for `awesome-unraid` sync in `CI / SimpleLogin-AIO`
- made manual image publishing opt-in instead of automatic on all manual CI runs
- updated release workflow dispatches to explicitly request image publishing when needed
- clarified high-friction template field descriptions, including secret generation hints, expected formats, and provider-specific guidance
- corrected `simplelogin-aio.xml` CA metadata, including valid categories and a useful `Requires` notice
- added donation metadata to the Unraid template
- updated repo funding metadata to include GitHub Sponsors, Ko-fi, and Buy Me a Coffee
- expanded README funding links

## Why
- the previous sync flow depended on a successful `push` run to `main` with no clean manual fallback
- several template fields were technically correct but too ambiguous for beginners
- CA-facing metadata needed tighter alignment with current Unraid expectations
- repo/template funding metadata was incomplete

## Validation
- `python3 scripts/test-ci-flags.py`
- `python3 -m py_compile scripts/ci_flags.py scripts/test-ci-flags.py`
- `python3 scripts/validate-template.py`

## Notes
- this PR does not require a new app release or package tag
- after merge, the normal `push` workflow on `main` should be able to open or refresh the `awesome-unraid` sync PR
- if needed, `CI / SimpleLogin-AIO` can also be run manually with:
  - `sync_awesome_unraid=true`
  - `publish_images=false`
  - `run_smoke_test=false`
