### PR TITLE
ci(release): standardize fleet publish and validation flow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,6 +180,7 @@ jobs:
       - name: Validate shell and python scripts
         if: ${{ needs.detect-changes.outputs.build_related == 'true' || needs.detect-changes.outputs.tooling_related == 'true' }}
         run: |
+          bash -n scripts/validate-derived-repo.sh
           PYTHONPYCACHEPREFIX=/tmp/simplelogin-aio-pyc python3 -m py_compile scripts/ci_flags.py
           PYTHONPYCACHEPREFIX=/tmp/simplelogin-aio-pyc python3 -m py_compile scripts/check-upstream.py
           PYTHONPYCACHEPREFIX=/tmp/simplelogin-aio-pyc python3 -m py_compile scripts/validate-template.py

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -38,10 +38,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_COMMIT: ${{ steps.version.outputs.release_commit }}
-          WORKFLOW_NAME: CI / SimpleLogin-AIO
+          WORKFLOW_SELECTOR: build.yml
         run: |
           runs_json="$(gh run list \
-            --workflow "${WORKFLOW_NAME}" \
+            --workflow "${WORKFLOW_SELECTOR}" \
             --commit "${RELEASE_COMMIT}" \
             --limit 20 \
             --json databaseId,headSha,status,conclusion)"
@@ -67,7 +67,7 @@ jobs:
               sys.exit(0)
 
           print(
-              f"No successful '{os.environ['WORKFLOW_NAME']}' run was found for release commit {release_commit}.",
+              f"No successful workflow run was found for release commit {release_commit} using selector {os.environ['WORKFLOW_SELECTOR']}.",
               file=sys.stderr,
           )
           sys.exit(1)

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -12,7 +12,7 @@ plugins:
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
   enabled:
-    - go@1.21.0
+    - go@1.26.0
     - node@22.16.0
     - python@3.10.8
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
@@ -26,13 +26,14 @@ lint:
     - hadolint@2.14.0
     - isort@8.0.1
     - markdownlint@0.48.0
+    - oxipng@10.1.0
     - prettier@3.8.3
     - renovate@43.138.3
     - ruff@0.15.11
     - shellcheck@0.11.0
     - shfmt@3.6.0
     - taplo@0.10.0
-    - trufflehog@3.95.1
+    - trufflehog@3.95.2
     - yamllint@1.38.0
 actions:
   enabled:

--- a/scripts/validate-derived-repo.sh
+++ b/scripts/validate-derived-repo.sh
@@ -23,7 +23,7 @@ require_absent() {
 check_no_placeholder() {
 	local pattern="$1"
 	shift
-	if rg -n --fixed-strings "${pattern}" "$@" >/dev/null 2>&1; then
+	if grep -F -n -- "${pattern}" "$@" >/dev/null 2>&1; then
 		fail "found unresolved placeholder '${pattern}' in: $*"
 	fi
 }
@@ -68,7 +68,7 @@ if [[ -z ${effective_template_xml} ]]; then
 fi
 
 is_template_repo="false"
-if [[ -f .github/workflows/publish-release.yml ]] && rg -q --fixed-strings "Publish Release / Template" .github/workflows/publish-release.yml; then
+if [[ -f .github/workflows/publish-release.yml ]] && grep -F -q -- "Publish Release / Template" .github/workflows/publish-release.yml; then
 	is_template_repo="true"
 fi
 

--- a/scripts/validate-derived-repo.sh
+++ b/scripts/validate-derived-repo.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="${1:-.}"
+cd "${repo_root}"
+strict_placeholders="${STRICT_PLACEHOLDERS:-false}"
+
+fail() {
+	echo "template validation error: $*" >&2
+	exit 1
+}
+
+require_file() {
+	local path="$1"
+	[[ -f ${path} ]] || fail "missing required file: ${path}"
+}
+
+require_absent() {
+	local path="$1"
+	[[ ! -e ${path} ]] || fail "remove template placeholder path in derived repo: ${path}"
+}
+
+check_no_placeholder() {
+	local pattern="$1"
+	shift
+	if rg -n --fixed-strings "${pattern}" "$@" >/dev/null 2>&1; then
+		fail "found unresolved placeholder '${pattern}' in: $*"
+	fi
+}
+
+require_file "Dockerfile"
+require_file "README.md"
+require_file "pyproject.toml"
+require_file "scripts/ci_flags.py"
+require_file "tests/unit/test_ci_flags.py"
+require_file "tests/template/test_validate_template.py"
+require_file "tests/integration/test_container_runtime.py"
+require_file "scripts/validate-template.py"
+require_file "scripts/update-template-changes.py"
+require_file ".github/FUNDING.yml"
+require_file "SECURITY.md"
+require_file ".github/pull_request_template.md"
+require_file ".github/ISSUE_TEMPLATE/bug_report.yml"
+require_file ".github/ISSUE_TEMPLATE/feature_request.yml"
+require_file ".github/ISSUE_TEMPLATE/installation_help.yml"
+require_file ".github/ISSUE_TEMPLATE/config.yml"
+require_file "renovate.json"
+require_absent ".github/CODEOWNERS"
+
+effective_template_xml="${TEMPLATE_XML-}"
+if [[ -z ${effective_template_xml} ]]; then
+	repo_name="${PWD##*/}"
+	inferred_repo_xml="${repo_name}.xml"
+	if [[ -f ${inferred_repo_xml} ]]; then
+		effective_template_xml="${inferred_repo_xml}"
+	else
+		root_xml_files=()
+		shopt -s nullglob
+		for xml_path in ./*.xml; do
+			[[ -f ${xml_path} ]] || continue
+			root_xml_files+=("${xml_path#./}")
+		done
+		shopt -u nullglob
+		if [[ ${#root_xml_files[@]} -eq 1 ]]; then
+			effective_template_xml="${root_xml_files[0]}"
+		fi
+	fi
+fi
+
+is_template_repo="false"
+if [[ -f .github/workflows/publish-release.yml ]] && rg -q --fixed-strings "Publish Release / Template" .github/workflows/publish-release.yml; then
+	is_template_repo="true"
+fi
+
+if [[ -n ${effective_template_xml} ]]; then
+	require_file "${effective_template_xml}"
+	if [[ ${is_template_repo} != "true" ]]; then
+		require_absent "template-aio.xml"
+	fi
+fi
+
+xml_files=()
+if [[ -n ${effective_template_xml} ]] && [[ -f ${effective_template_xml} ]]; then
+	xml_files+=("${effective_template_xml}")
+fi
+
+if [[ ${strict_placeholders} == "true" ]]; then
+	check_no_placeholder "Replace this starter base with the real upstream image once the derived repo is wired." "Dockerfile"
+	if [[ ${#xml_files[@]} -gt 0 ]]; then
+		check_no_placeholder "yourapp-aio" "${xml_files[@]}"
+		check_no_placeholder "Replace this overview with the real app description and first-run guidance." "${xml_files[@]}"
+		check_no_placeholder "replace-with-real-search-terms" "${xml_files[@]}"
+		check_no_placeholder "Replace this with any real operational prerequisites or remove it." "${xml_files[@]}"
+		check_no_placeholder "https://github.com/JSONbored/yourapp-aio/releases" "${xml_files[@]}"
+	fi
+	check_no_placeholder "aio-template starter app" rootfs/etc/services.d/app/run rootfs/usr/local/bin/aio-template-app.py
+fi
+
+echo "Derived repo validation passed."

--- a/tests/template/test_validate_derived_repo.py
+++ b/tests/template/test_validate_derived_repo.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from tests.conftest import REPO_ROOT
+from tests.helpers import pytest_env, run_command
+
+
+def test_validate_derived_repo_script_passes_with_strict_placeholders() -> None:
+    env = pytest_env()
+    env["STRICT_PLACEHOLDERS"] = "true"
+    result = run_command(
+        ["bash", "scripts/validate-derived-repo.sh", "."],
+        cwd=REPO_ROOT,
+        env=env,
+    )
+    assert "Derived repo validation passed." in result.stdout  # nosec B101


### PR DESCRIPTION
## Summary
- add the shared derived-repo guardrail validation to `simplelogin-aio`

## What changed
- add `scripts/validate-derived-repo.sh`
- add pytest coverage for the derived-repo validator
- lint the new validator in the build workflow

## Why
- the other AIO repos already validate this guardrail surface
- `simplelogin-aio` had drifted behind the fleet baseline

## Validation
- `trunk check --show-existing --all`
- `python3 scripts/validate-template.py`
- `pytest tests/unit tests/template`
- `pytest tests/integration -m integration`
- `pytest tests/unit tests/template --junit-xml=reports/pytest-unit.xml -o junit_family=xunit1`
- `pytest tests/integration -m integration --junit-xml=reports/pytest-integration.xml -o junit_family=xunit1`
- `/tmp/trunk-analytics-cli/trunk-analytics-cli validate --junit-paths "reports/pytest-unit.xml,reports/pytest-integration.xml"`
- `git diff --check`
