### PR TITLE
ci(fleet): centralize trunk config and gate release tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -440,30 +440,36 @@ jobs:
           upstream_version="${raw_version%%@*}"
           upstream_digest="$(sed -n 's/^ARG UPSTREAM_IMAGE_DIGEST=//p' Dockerfile | head -n1)"
           changelog_version="$(python3 scripts/release.py latest-changelog-version 2>/dev/null || true)"
-          aio_revision=""
+          commit_message="$(git log -1 --pretty=%B)"
+          aio_track=""
+          release_package_tag=""
+          version_label="${upstream_version}"
+          wrapper_track="main"
           case "${changelog_version}" in
             "${upstream_version}"-aio.*)
               candidate_revision="${changelog_version##*.}"
-              if [[ "${candidate_revision}" =~ ^[0-9]+$ ]]; then
-                aio_revision="${candidate_revision}"
+              if [[ "${candidate_revision}" =~ ^[0-9]+$ ]] && printf '%s\n' "${commit_message}" | grep -Fxq "chore(release): ${changelog_version}"; then
+                aio_track="aio-v${candidate_revision}"
+                release_package_tag="${upstream_version}-${aio_track}"
+                version_label="${release_package_tag}"
+                wrapper_track="${aio_track}"
               fi
               ;;
           esac
-          if [[ -n "${aio_revision}" ]]; then
-            aio_track="aio-v${aio_revision}"
-          else
-            aio_track="aio-v1"
-          fi
 
           {
             echo "upstream_version=${upstream_version}"
             echo "upstream_digest=${upstream_digest}"
-            echo "aio_track=${aio_track}"
+            echo "release_package_tag=${release_package_tag}"
+            echo "version_label=${version_label}"
+            echo "wrapper_track=${wrapper_track}"
             echo "tags<<EOF"
             echo "${image_ghcr}:latest"
             if [[ -n "${upstream_version}" ]]; then
               echo "${image_ghcr}:${upstream_version}"
-              echo "${image_ghcr}:${upstream_version}-${aio_track}"
+              if [[ -n "${release_package_tag}" ]]; then
+                echo "${image_ghcr}:${release_package_tag}"
+              fi
             fi
             echo "${sha_tag_ghcr}"
 
@@ -471,7 +477,9 @@ jobs:
               echo "${image_dockerhub}:latest"
               if [[ -n "${upstream_version}" ]]; then
                 echo "${image_dockerhub}:${upstream_version}"
-                echo "${image_dockerhub}:${upstream_version}-${aio_track}"
+                if [[ -n "${release_package_tag}" ]]; then
+                  echo "${image_dockerhub}:${release_package_tag}"
+                fi
               fi
               echo "${image_dockerhub}:sha-${GITHUB_SHA}"
             fi
@@ -490,14 +498,14 @@ jobs:
           labels: |
             org.opencontainers.image.source=https://github.com/JSONbored/simplelogin-aio
             org.opencontainers.image.title=simplelogin-aio
-            org.opencontainers.image.version=${{ steps.prep.outputs.upstream_version || '' }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.version_label || '' }}
             org.opencontainers.image.description=Unraid-first AIO wrapper image for SimpleLogin (web, jobs, email, postgres, redis, postfix)
             io.jsonbored.upstream.name=SimpleLogin
             io.jsonbored.upstream.version=${{ steps.prep.outputs.upstream_version || '' }}
             io.jsonbored.upstream.digest=${{ steps.prep.outputs.upstream_digest || '' }}
             io.jsonbored.wrapper.name=simplelogin-aio
             io.jsonbored.wrapper.type=unraid-aio
-            io.jsonbored.wrapper.track=${{ steps.prep.outputs.aio_track }}
+            io.jsonbored.wrapper.track=${{ steps.prep.outputs.wrapper_track || '' }}
 
   sync-awesome-unraid:
     if: ${{ needs.detect-changes.outputs.xml_related == 'true' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -9,35 +9,6 @@ plugins:
     - id: trunk
       ref: v1.7.6
       uri: https://github.com/trunk-io/plugins
-# Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
-runtimes:
-  enabled:
-    - go@1.26.0
-    - node@22.16.0
-    - python@3.10.8
-# This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
-lint:
-  enabled:
-    - actionlint@1.7.12
-    - bandit@1.9.4
-    - black@26.3.1
-    - checkov@3.2.524
-    - git-diff-check
-    - hadolint@2.14.0
-    - isort@8.0.1
-    - markdownlint@0.48.0
-    - oxipng@10.1.0
-    - prettier@3.8.3
-    - renovate@43.138.3
-    - ruff@0.15.11
-    - shellcheck@0.11.0
-    - shfmt@3.6.0
-    - taplo@0.10.0
-    - trufflehog@3.95.2
-    - yamllint@1.38.0
-actions:
-  enabled:
-    - trunk-announce
-    - trunk-check-pre-push
-    - trunk-fmt-pre-commit
-    - trunk-upgrade-available
+    - id: unraid-aio
+      ref: v0.1.0
+      uri: https://github.com/JSONbored/unraid-aio-trunk-config

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -14,8 +14,9 @@ Every `main` build publishes:
 
 - `latest`
 - the exact pinned upstream version
-- an explicit packaging line tag like `v4.79.0-aio-v1`
 - `sha-<commit>`
+
+Release commits also publish the immutable packaging line tag, for example `v4.79.0-aio-v1`. Ordinary `main` pushes do not overwrite that release tag.
 
 ## Release flow
 


### PR DESCRIPTION
## Summary
- consume the shared unraid-aio Trunk plugin config
- only emit immutable release tags on real release commits
- document the publish and release tag behavior

## Validation
- trunk check --show-existing --all
- python3 scripts/validate-template.py
- pytest tests/unit tests/template
- pytest tests/integration -m integration
- ./trunk-analytics-cli validate --junit-paths "reports/pytest-unit.xml,reports/pytest-integration.xml"
- git diff --check