### PR TITLE
ci(fleet): pin shared validation policy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ concurrency:
 
 jobs:
   aio-build:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@7bfda522056a626fe401b734fbdd97239c0955b2
+    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@ba033c4af5d16e7fcb4962f77e527eb5d86782fa
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   check-upstream:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@7bfda522056a626fe401b734fbdd97239c0955b2
+    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@ba033c4af5d16e7fcb4962f77e527eb5d86782fa
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   publish-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@7bfda522056a626fe401b734fbdd97239c0955b2
+    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@ba033c4af5d16e7fcb4962f77e527eb5d86782fa
     permissions:
       actions: read
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   prepare-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@7bfda522056a626fe401b734fbdd97239c0955b2
+    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@ba033c4af5d16e7fcb4962f77e527eb5d86782fa
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- Re-pins this repo's thin AIO workflow callers to the latest aio-fleet validation-policy release.

## What changed
- Updates build, upstream-check, release, and publish workflow callers to `JSONbored/aio-fleet@ba033c4af5d16e7fcb4962f77e527eb5d86782fa`
- Keeps repo-specific workflow inputs unchanged

## Why
- Enables the new centralized fleet policy validators from aio-fleet
- Keeps workflow drift, pinned-action checks, catalog metadata checks, and publish-platform policy in the control plane

## Validation
- Generated with `aio-fleet sync-workflows`
- `aio-fleet verify-caller` passed locally
- `aio-fleet validate-repo` passed locally
- `git diff --check` passed locally

## Notes
- This is workflow-only and should not publish images or sync Community Apps XML.
- GitHub may require allowlisting the new pinned reusable workflow SHA before checks run.
