### PR TITLE
fix(template): normalize SimpleLogin CA name and fleet cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,55 +4,55 @@ on:
   push:
     branches: [main]
     paths:
-      - ".github/**"
-      - ".github/workflows/**"
-      - ".trunk/**"
-      - "AGENTS.md"
-      - "CHANGELOG.md"
-      - "Dockerfile"
-      - "README.md"
-      - "SECURITY.md"
-      - "SUPPORT.md"
-      - "assets/**"
-      - "cliff.toml"
-      - "components.toml"
-      - "components/**"
-      - "docs/**"
-      - "docs/upstream/**"
-      - "pyproject.toml"
-      - "renovate.json"
-      - "requirements-dev.txt"
-      - "rootfs/**"
-      - "scripts/**"
-      - "simplelogin-aio.xml"
-      - "tests/**"
-      - "upstream.toml"
+      - .github/**
+      - .github/workflows/**
+      - .trunk/**
+      - AGENTS.md
+      - CHANGELOG.md
+      - Dockerfile
+      - README.md
+      - SECURITY.md
+      - SUPPORT.md
+      - assets/**
+      - cliff.toml
+      - components.toml
+      - components/**
+      - docs/**
+      - docs/upstream/**
+      - pyproject.toml
+      - renovate.json
+      - requirements-dev.txt
+      - rootfs/**
+      - scripts/**
+      - simplelogin-aio.xml
+      - tests/**
+      - upstream.toml
   pull_request:
     branches: [main]
     paths:
-      - ".github/**"
-      - ".github/workflows/**"
-      - ".trunk/**"
-      - "AGENTS.md"
-      - "CHANGELOG.md"
-      - "Dockerfile"
-      - "README.md"
-      - "SECURITY.md"
-      - "SUPPORT.md"
-      - "assets/**"
-      - "cliff.toml"
-      - "components.toml"
-      - "components/**"
-      - "docs/**"
-      - "docs/upstream/**"
-      - "pyproject.toml"
-      - "renovate.json"
-      - "requirements-dev.txt"
-      - "rootfs/**"
-      - "scripts/**"
-      - "simplelogin-aio.xml"
-      - "tests/**"
-      - "upstream.toml"
+      - .github/**
+      - .github/workflows/**
+      - .trunk/**
+      - AGENTS.md
+      - CHANGELOG.md
+      - Dockerfile
+      - README.md
+      - SECURITY.md
+      - SUPPORT.md
+      - assets/**
+      - cliff.toml
+      - components.toml
+      - components/**
+      - docs/**
+      - docs/upstream/**
+      - pyproject.toml
+      - renovate.json
+      - requirements-dev.txt
+      - rootfs/**
+      - scripts/**
+      - simplelogin-aio.xml
+      - tests/**
+      - upstream.toml
   workflow_dispatch:
 
 permissions:
@@ -64,7 +64,7 @@ concurrency:
 
 jobs:
   aio-build:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@388300f0f98701ea81bd8185660257d06cd8f472
+    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@4aea17371db2faf5ba759cda63b4f46aac514162
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -2,7 +2,7 @@ name: Check Upstream Version
 
 on:
   schedule:
-    - cron: "23 7 * * 1"
+    - cron: 23 7 * * 1
   workflow_dispatch:
 
 permissions:
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   check-upstream:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@388300f0f98701ea81bd8185660257d06cd8f472
+    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@4aea17371db2faf5ba759cda63b4f46aac514162
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   publish-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@388300f0f98701ea81bd8185660257d06cd8f472
+    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@4aea17371db2faf5ba759cda63b4f46aac514162
     permissions:
       actions: read
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   prepare-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@388300f0f98701ea81bd8185660257d06cd8f472
+    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@4aea17371db2faf5ba759cda63b4f46aac514162
     permissions:
       contents: write
       pull-requests: write

--- a/.trunk/configs/.markdownlint.yaml
+++ b/.trunk/configs/.markdownlint.yaml
@@ -1,2 +1,4 @@
 # Prettier friendly markdownlint config (all formatting rules disabled)
 extends: markdownlint/style/prettier
+MD024:
+  siblings_only: true

--- a/.trunk/configs/.shellcheckrc
+++ b/.trunk/configs/.shellcheckrc
@@ -1,6 +1,5 @@
 enable=all
 source-path=SCRIPTDIR
-disable=SC2154
 
 # If you're having issues with shellcheck following source, disable the errors via:
 # disable=SC1090

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
 ## v4.80.1-aio.2 - 2026-04-25
+
 ### CI
+
 - Allow manual awesome-unraid sync
 - Require Trunk uploads and PR integration
 - Gate releases on validated CI and template checks
@@ -18,20 +21,20 @@ All notable changes to this project will be documented in this file.
 - Fetch history for release tag lookup
 - Consolidate pytest workflow steps
 
-
 ### Dependency Updates
+
 - Update trunk-io/analytics-uploader action to v2
 - Update dependency pytest to v9 [security]
 
-
 ### Documentation
+
 - Clarify config field instructions
 - Tighten CA metadata
 - Add donation links
 - Add buy me a coffee
 
-
 ### Fixes
+
 - Unblock first login and tighten required fields
 - Support encoded external database credentials
 - Sync relay mode with catalog
@@ -43,19 +46,18 @@ All notable changes to this project will be documented in this file.
 - Classify local action changes
 - Fail fast on init errors
 
-
 ### Other Changes
+
 - Merge branch 'main' into codex/manual-awesome-sync
 - Migrate smoke tests to pytest
 - Merge branch 'main' into codex/ci-diagnostics-fixes
 - Merge branch 'main' into codex/release-target-immutability
 
-
 ### Tests
+
 - Use docker volumes for runtime persistence
 - Add derived repo guardrail validation
 - Cover action and container contracts
-
 
 ## v4.80.1-aio.1 - 2026-04-16
 

--- a/rootfs/etc/cont-init.d/01-validate-env.sh
+++ b/rootfs/etc/cont-init.d/01-validate-env.sh
@@ -1,5 +1,6 @@
 #!/command/with-contenv bash
 # shellcheck shell=bash
+# shellcheck disable=SC2154
 set -euo pipefail
 
 # trunk-ignore(shellcheck/SC1091)

--- a/rootfs/etc/cont-init.d/03-write-env.sh
+++ b/rootfs/etc/cont-init.d/03-write-env.sh
@@ -1,5 +1,6 @@
 #!/command/with-contenv bash
 # shellcheck shell=bash
+# shellcheck disable=SC2154
 set -euo pipefail
 # trunk-ignore(shellcheck/SC1091)
 source /etc/simplelogin-aio/env-helpers.sh

--- a/rootfs/etc/cont-init.d/04-configure-postfix.sh
+++ b/rootfs/etc/cont-init.d/04-configure-postfix.sh
@@ -1,5 +1,6 @@
 #!/command/with-contenv bash
 # shellcheck shell=bash
+# shellcheck disable=SC2154
 set -euo pipefail
 
 echo "Configuring Postfix MTA routing..."

--- a/scripts/validate-derived-repo.sh
+++ b/scripts/validate-derived-repo.sh
@@ -9,7 +9,7 @@ if [[ ${strict_placeholders} == "true" ]]; then
 	args+=(--strict-placeholders)
 fi
 
-if python3 -c "import aio_fleet" >/dev/null 2>&1; then
+if python3 -c "import aio_fleet.cli" >/dev/null 2>&1; then
 	exec python3 -m aio_fleet.cli "${args[@]}"
 fi
 
@@ -27,7 +27,11 @@ candidate_roots+=(
 
 for candidate in "${candidate_roots[@]}"; do
 	if [[ -d ${candidate}/src/aio_fleet ]]; then
-		PYTHONPATH="${candidate}/src${PYTHONPATH:+:${PYTHONPATH}}" exec python3 -m aio_fleet.cli "${args[@]}"
+		python_bin="python3"
+		if [[ -x ${candidate}/.venv/bin/python ]]; then
+			python_bin="${candidate}/.venv/bin/python"
+		fi
+		PYTHONPATH="${candidate}/src${PYTHONPATH:+:${PYTHONPATH}}" exec "${python_bin}" -m aio_fleet.cli "${args[@]}"
 	fi
 done
 

--- a/simplelogin-aio.xml
+++ b/simplelogin-aio.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <Container version="2">
-  <Name>SimpleLogin-AIO</Name>
+  <Name>simplelogin-aio</Name>
   <Repository>ghcr.io/jsonbored/simplelogin-aio:latest</Repository>
   <Registry>https://ghcr.io/jsonbored/simplelogin-aio</Registry>
   <Network>bridge</Network>

--- a/tests/template/test_container_contract.py
+++ b/tests/template/test_container_contract.py
@@ -70,6 +70,7 @@ def test_unraid_metadata_contract_is_complete_and_unprivileged() -> None:
     root = _template_root()
 
     assert root.findtext("Privileged") == "false"  # nosec B101
+    assert root.findtext("Name") == "simplelogin-aio"  # nosec B101
     for tag in (
         "Name",
         "Repository",


### PR DESCRIPTION
## Summary
- Fixes the SimpleLogin Community Apps display name to use the lowercase `simplelogin-aio` slug.
- Keeps the existing fleet workflow/boilerplate/Trunk cleanup on this branch.

## What changed
- Changes `<Name>` from `SimpleLogin-AIO` to `simplelogin-aio` in the source Unraid XML template.
- Adds a template contract assertion for the lowercase CA name.
- Retains shared workflow caller, derived-validator, and Trunk cleanup from aio-fleet commit 4aea17371db2faf5ba759cda63b4f46aac514162.

## Why
- All other active AIO templates use lowercase slugs in Community Apps, and the current SimpleLogin entry displays inconsistently.
- Source XML must be fixed first so CI can sync the validated template into `awesome-unraid`.

## Validation
- `.venv/bin/python scripts/validate-template.py --all`
- `.venv/bin/python -m pytest tests/unit tests/template`
- `trunk check --show-existing --all --no-fix --no-progress --color=false`
- `git diff --check`
- `aio-fleet validate --repo simplelogin-aio`

## Notes
- Do not hand-edit the `awesome-unraid` catalog copy for this; merge this source repo PR and let the catalog sync workflow carry the XML downstream.
