### PR TITLE
ci(fleet): pin next-wave aio-fleet workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ concurrency:
 
 jobs:
   aio-build:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@85cd5de8869f371da44f1577117275511ead01c0
+    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@ce6221adb01de3fbe16b40fa0274c950c1ccd225
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   check-upstream:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@85cd5de8869f371da44f1577117275511ead01c0
+    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@ce6221adb01de3fbe16b40fa0274c950c1ccd225
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   publish-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@85cd5de8869f371da44f1577117275511ead01c0
+    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@ce6221adb01de3fbe16b40fa0274c950c1ccd225
     permissions:
       actions: read
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   prepare-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@85cd5de8869f371da44f1577117275511ead01c0
+    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@ce6221adb01de3fbe16b40fa0274c950c1ccd225
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- Pins reusable workflow callers to aio-fleet main commit ce6221a.

## What changed
- Updates build, upstream-check, release, and publish-release caller workflow refs.

## Why
- Makes this repo use the landed next-wave reusable workflow implementation, including GitHub App token resolution and shared operator fixes.

## Validation
- python -m aio_fleet sync-workflows --dry-run
- python -m aio_fleet validate --all
- trunk check --show-existing --all --no-fix --no-progress --color=false
- git diff --check