### PR TITLE
fix(template): prefer Docker Hub image metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ In other words, the template is responsible for exposing deployment-time and int
 - Release notes are generated with `git-cliff`.
 - The Unraid template `<Changes>` block is synced from `CHANGELOG.md` during release preparation.
 - `main` publishes `latest`, the pinned upstream version tag, an explicit AIO packaging line tag, and `sha-<commit>`.
-- When Docker Hub credentials are configured, the same publish flow can push Docker Hub tags in parallel with GHCR.
+- The Unraid template uses Docker Hub image tags for Community Applications metadata.
 
 See [docs/releases.md](docs/releases.md) for the release workflow details.
 

--- a/scripts/validate-template.py
+++ b/scripts/validate-template.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import json
+import os
 import re
+import subprocess  # nosec B404
 import sys
 from pathlib import Path
 
@@ -133,6 +135,62 @@ LEGACY_CHANGELOG_MARKERS = (
 )
 
 
+def run_common_template_validation() -> int:
+    candidates = []
+    explicit = os.environ.get("AIO_FLEET_MANIFEST", "").strip()
+    if explicit:
+        candidates.append(Path(explicit))
+    candidates.extend(
+        [
+            ROOT / ".aio-fleet" / "fleet.yml",
+            ROOT.parent / "aio-fleet" / "fleet.yml",
+        ]
+    )
+    manifest = next((candidate for candidate in candidates if candidate.exists()), None)
+    if manifest is None:
+        print(
+            "warning: aio-fleet manifest not found; skipping common template validation",
+            file=sys.stderr,
+        )
+        return 0
+
+    env = os.environ.copy()
+    fleet_src = manifest.parent / "src"
+    if fleet_src.exists():
+        existing = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = (
+            f"{fleet_src}{os.pathsep}{existing}" if existing else str(fleet_src)
+        )
+    python = sys.executable
+    fleet_python = manifest.parent / ".venv" / "bin" / "python"
+    if fleet_python.exists():
+        python = str(fleet_python)
+
+    result = subprocess.run(  # nosec B603
+        [
+            python,
+            "-m",
+            "aio_fleet.cli",
+            "--manifest",
+            str(manifest),
+            "validate-template-common",
+            "--repo",
+            ROOT.name,
+            "--repo-path",
+            str(ROOT),
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+    if result.stdout:
+        print(result.stdout, end="")
+    if result.stderr:
+        print(result.stderr, file=sys.stderr, end="")
+    return result.returncode
+
+
 def load_enum_contracts() -> dict[str, dict[str, object]]:
     return json.loads(ENUM_CONTRACTS_PATH.read_text())
 
@@ -168,6 +226,10 @@ def validate_changes(changes: str) -> str | None:
 
 
 def main() -> int:
+    common_status = run_common_template_validation()
+    if common_status:
+        return common_status
+
     tree = ET.parse(TEMPLATE_PATH)
     root = tree.getroot()
 

--- a/simplelogin-aio.xml
+++ b/simplelogin-aio.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>simplelogin-aio</Name>
-  <Repository>ghcr.io/jsonbored/simplelogin-aio:latest</Repository>
-  <Registry>https://ghcr.io/jsonbored/simplelogin-aio</Registry>
+  <Repository>jsonbored/simplelogin-aio:latest</Repository>
+  <Registry>https://hub.docker.com/r/jsonbored/simplelogin-aio</Registry>
   <Network>bridge</Network>
   <MyIP/>
   <Shell>sh</Shell>


### PR DESCRIPTION
## Summary
- switch SimpleLogin CA image metadata to Docker Hub
- run shared aio-fleet template metadata validation before SimpleLogin-specific target checks
- update release docs to describe Docker Hub CA metadata

## Validation
- .venv/bin/python scripts/validate-template.py
- .venv/bin/python -m pytest tests/template