### PR TITLE
docs(ci): document central app test dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Run it locally with:
 ```bash
 python3 -m venv .venv
 . .venv/bin/activate
-pip install -r requirements-dev.txt
+pip install -e "../aio-fleet[app-tests]"
 pytest tests/unit
 pytest tests/integration -m integration
 ```


### PR DESCRIPTION
## Summary
- replace stale requirements-dev.txt setup references with the central aio-fleet app test extras
- keep local validation docs aligned with the control-plane dependency model

## What changed
- update README/local validation setup docs to install ../aio-fleet[app-tests]

## Why
- app repos no longer own shared dev dependency files; aio-fleet is the central source for shared test dependencies

## Validation
- git diff --check
- searched active repo docs for retired shared tooling references