### PR TITLE
build(docker): harden apt package installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,9 @@ ENV PYTHONWARNINGS="ignore::SyntaxWarning"
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # trunk-ignore(hadolint/DL3008)
-RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y --no-install-recommends \
+RUN find /etc/apt -type f \( -name '*.list' -o -name '*.sources' \) -exec sed -i 's|http://|https://|g' {} + && \
+    printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' > /etc/apt/apt.conf.d/80-retries && \
+    apt-get update && apt-get -y dist-upgrade && apt-get install -y --no-install-recommends \
     curl \
     xz-utils \
     ca-certificates \


### PR DESCRIPTION
## Summary
- Add apt retry and timeout configuration before package installs.
- Rewrite inherited apt sources from http to https before update/install.

## Why
- Package mirror stalls caused publish-time Docker builds to fail or hang in central fleet checks.

## Validation
- docker build --progress=plain --platform linux/amd64 -t simplelogin-aio:diagnose .
- aio-fleet validate --all
- aio-fleet cleanup-repo --all --verify
- aio-fleet trunk run --repo simplelogin-aio --repo-path ../simplelogin-aio --no-fix
- git diff --check