### PR TITLE
docs(support): clarify simplelogin registration mailbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you want the simplest supported path:
 4. Leave dropdown-style advanced enum fields such as `ADMIN_FIDO_REQUIRED` on their documented values only. For most installs that means leaving `ADMIN_FIDO_REQUIRED=none`.
 5. Forward inbound TCP 25 from your router/firewall to the Unraid host.
 6. Start the container and wait for first-boot initialization to complete.
-7. Create your first account in the web UI, then disable registration in Advanced View if you want a private instance.
+7. Create your first account in the web UI with an existing personal mailbox that is not on `EMAIL_DOMAIN`, then disable registration in Advanced View if you want a private instance.
 8. Add the DNS records from [docs/simplelogin-setup.md](docs/simplelogin-setup.md).
 
 For most users, that is enough to get a working instance online.
@@ -74,6 +74,7 @@ In other words, the template is responsible for exposing deployment-time and int
 - `/pgp` is the optional persistent GnuPG home.
 - `/custom-assets` is an optional advanced mount for file-based upstream settings.
 - DKIM keys are persisted under `/appdata/dkim` and symlinked into the in-container paths the app expects.
+- SimpleLogin treats `EMAIL_DOMAIN` as an alias domain. Registration emails must use a separate existing mailbox, not an address hosted by the new alias domain.
 
 ## Publishing and Releases
 

--- a/docs/simplelogin-setup.md
+++ b/docs/simplelogin-setup.md
@@ -15,6 +15,8 @@ Set the Unraid template like this:
 - `EMAIL_DOMAIN=example.com`
 - `SUPPORT_EMAIL=support@example.com` (use a mailbox that already exists)
 
+`EMAIL_DOMAIN` becomes a SimpleLogin alias domain. Do not use an address on that same domain as the first account mailbox; register with an existing external mailbox you can already receive, then add alias-domain routing inside SimpleLogin after activation.
+
 ## 2. Add DNS Records
 
 At minimum, add:
@@ -69,7 +71,7 @@ The wrapper now validates the rendered `.env` before starting the web app, job r
 After the container comes up:
 
 - open the web UI on port `7777`
-- create your first account in the web UI while registration is still enabled
+- create your first account in the web UI while registration is still enabled, using a personal mailbox that is not on `EMAIL_DOMAIN`
 - once your first account exists, set `DISABLE_REGISTRATION=true` in Advanced View and restart if you want a private instance
 - confirm `/health` responds
 - check the logs for any Postfix relay or DNS warnings

--- a/simplelogin-aio.xml
+++ b/simplelogin-aio.xml
@@ -17,7 +17,7 @@
 [b]Quick Install (Beginners)[/b]&#xD;
 1. Install this template in Unraid.&#xD;
 2. Set [code]URL[/code], [code]EMAIL_DOMAIN[/code], [code]SUPPORT_EMAIL[/code], and [code]FLASK_SECRET[/code].&#xD;
-3. Leave registration enabled for first boot, create your first account in the web UI, then disable registration later in Advanced View if you want a private instance.&#xD;
+3. Leave registration enabled for first boot, create your first account with a mailbox that is not on [code]EMAIL_DOMAIN[/code], then disable registration later in Advanced View if you want a private instance.&#xD;
 4. Choose an outbound relay mode if your ISP blocks outbound TCP 25.&#xD;
 5. Forward inbound TCP 25 from your router/firewall to the Unraid host if you want internet mail delivery.&#xD;
 6. Start the container, wait for first boot to finish, then add the required DNS records from the setup guide.&#xD;
@@ -75,7 +75,7 @@
 
   <!-- Core required -->
   <Config Name="App URL" Target="URL" Default="https://app.example.com" Mode="" Description="Canonical HTTPS URL for the dashboard, for example https://app.example.com. This does not need to be the same as your SMTP/MX hostname." Type="Variable" Display="always" Required="true" Mask="false"/>
-  <Config Name="Primary Email Domain" Target="EMAIL_DOMAIN" Default="example.com" Mode="" Description="Real public alias domain, for example example.com. Do not use a private-only tailnet domain here." Type="Variable" Display="always" Required="true" Mask="false"/>
+  <Config Name="Primary Email Domain" Target="EMAIL_DOMAIN" Default="example.com" Mode="" Description="Real public alias domain, for example example.com. Do not use a private-only tailnet domain here. First-account registration must use a separate existing mailbox, not this alias domain." Type="Variable" Display="always" Required="true" Mask="false"/>
   <Config Name="Support Email" Target="SUPPORT_EMAIL" Default="support@example.com" Mode="" Description="Working mailbox used for system mail, for example support@example.com. Use an address that already exists." Type="Variable" Display="always" Required="true" Mask="false"/>
   <Config Name="Flask Secret" Target="FLASK_SECRET" Default="" Mode="" Description="Long random app secret. Generate with: openssl rand -hex 32" Type="Variable" Display="always" Required="true" Mask="true"/>
   <Config Name="SMTP Relay Mode" Target="RELAY_MODE" Default="direct|brevo|protonmail|gmail|mailgun|custom" Mode="" Description="Outbound mail mode. Choose one of the built-in dropdown values only: direct, brevo, protonmail, gmail, mailgun, or custom. Use a relay provider if your ISP blocks outbound TCP 25." Type="Variable" Display="always" Required="true" Mask="false">direct</Config>

--- a/tests/integration/test_container_runtime.py
+++ b/tests/integration/test_container_runtime.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import re
 import time
+import urllib.parse
+import urllib.request
+from http.cookiejar import CookieJar
 
 import pytest
 
@@ -32,6 +36,60 @@ def test_happy_path_boot_and_restart(runtime: DockerRuntime) -> None:
         container.wait_for_smtp()
         assert container.path_exists("/appdata/postgres/PG_VERSION")  # nosec B101
         assert container.path_exists("/appdata/sl/.initialized")  # nosec B101
+
+
+def _submit_registration(container, email: str) -> str:
+    register_url = f"http://127.0.0.1:{container.http_port}/auth/register"
+    opener = urllib.request.build_opener(
+        urllib.request.HTTPCookieProcessor(CookieJar())
+    )
+    register_page = (
+        opener.open(register_url, timeout=20).read().decode("utf-8", "replace")
+    )
+    csrf_match = re.search(r'name="csrf_token"[^>]*value="([^"]+)"', register_page)
+    assert csrf_match is not None  # nosec B101
+
+    post_data = urllib.parse.urlencode(
+        {
+            "csrf_token": csrf_match.group(1),
+            "email": email,
+            "password": "x" * 16,
+        }
+    ).encode()
+    request = urllib.request.Request(
+        register_url,
+        data=post_data,
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Referer": register_url,
+        },
+    )
+    return opener.open(request, timeout=20).read().decode("utf-8", "replace")
+
+
+def test_registration_uses_external_personal_mailbox(runtime: DockerRuntime) -> None:
+    with runtime.container(
+        env_overrides={
+            "DISABLE_REGISTRATION": "false",
+            "NOT_SEND_EMAIL": "true",
+        }
+    ) as container:
+        container.wait_for_http()
+        container.wait_for_smtp()
+
+        _submit_registration(container, "first-user@proton.me")
+        container.wait_for_log("send email to first-user@proton.me")
+
+        rejected_body = _submit_registration(container, "alias-user@example.com")
+        assert (  # nosec B101
+            "You cannot use this email address as your personal inbox." in rejected_body
+        )
+
+        users = container.exec(
+            "su -s /bin/sh postgres -c "
+            "\"psql -d simplelogin -Atc 'select email,activated from users order by email;'\""
+        ).stdout.strip()
+        assert users == "first-user@proton.me|f"  # nosec B101
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- clarify that first-account registration must use an existing mailbox outside `EMAIL_DOMAIN`
- add a Docker integration guard for the accepted external-mailbox path and rejected alias-domain path

## Why
- issue #69 matched upstream SimpleLogin behavior when a user tries to register with the alias domain itself; the AIO docs/template did not make that visible enough

## Validation
- `.venv/bin/python -m pytest tests/unit tests/template -q`
- `.venv/bin/python -m pytest tests/integration/test_container_runtime.py::test_registration_uses_external_personal_mailbox -q`
- `.venv/bin/python -m pytest tests/integration -m integration -q`
- `uv run aio-fleet validate-repo --repo simplelogin-aio --repo-path /Users/shadowbook/Documents/simplelogin-aio`

## Notes
- no container/runtime change required