### PR TITLE
chore(release): v4.80.6-aio.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## v4.80.6-aio.2 - 2026-05-17
+
+### Documentation
+
+- Clarify simplelogin registration mailbox
+
 ## v4.80.6-aio.1 - 2026-05-17
 
 ### Maintenance

--- a/simplelogin-aio.xml
+++ b/simplelogin-aio.xml
@@ -33,7 +33,7 @@
 - For the simplest operation, keep the internal Postgres/Redis/Postfix defaults and only set the small required config set above.</Overview>
   <Changes>### 2026-05-17&#xD;
 - Generated from CHANGELOG.md during release preparation. Do not edit manually.&#xD;
-- Bump simplelogin to v4.80.6 (#73)</Changes>
+- Clarify simplelogin registration mailbox</Changes>
   <Category>Network:Privacy Network:Web</Category>
   <WebUI>http://[IP]:[PORT:7777]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/simplelogin-aio.xml</TemplateURL>


### PR DESCRIPTION
## Summary
- prepare the SimpleLogin AIO follow-up release for the registration-mailbox documentation/test fix

## What changed
- add the `v4.80.6-aio.2` changelog entry
- refresh XML `<Changes>` from the release notes

## Why
- keeps release/package truth aligned after the support fix merged to main

## Validation
- `.venv/bin/python -m pytest tests/unit tests/template -q`
- `.venv/bin/python -m pytest tests/integration/test_container_runtime.py::test_registration_uses_external_personal_mailbox -q`
- `uv run aio-fleet validate-repo --repo simplelogin-aio --repo-path /Users/shadowbook/Documents/simplelogin-aio`
- `uv run aio-fleet trunk run --repo simplelogin-aio --repo-path /Users/shadowbook/Documents/simplelogin-aio --no-fix`

## Notes
- no upstream version change; this is the AIO release for the support/docs/test correction