### PR TITLE
fix(security): enforce verified TLS for SMTP relays

### DIFF
--- a/rootfs/etc/cont-init.d/04-configure-postfix.sh
+++ b/rootfs/etc/cont-init.d/04-configure-postfix.sh
@@ -141,7 +141,7 @@ if [[ ${RELAY_MODE:-direct} != "direct" ]]; then
 	postconf -e "smtp_sasl_auth_enable = yes"
 	postconf -e "smtp_sasl_security_options = noanonymous"
 	postconf -e "smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd"
-	postconf -e "smtp_tls_security_level = encrypt"
+	postconf -e "smtp_tls_security_level = secure"
 	postmap /etc/postfix/sasl_passwd
 	chmod 600 /etc/postfix/sasl_passwd /etc/postfix/sasl_passwd.db
 fi


### PR DESCRIPTION
### Motivation
- Prevent exposure of SMTP relay credentials when using remote relays (for example Proton Mail) by ensuring Postfix verifies the relay certificate and hostname before sending SASL credentials.

### Description
- Change `smtp_tls_security_level` from `encrypt` to `secure` for non-`direct` relay modes in `rootfs/etc/cont-init.d/04-configure-postfix.sh`, preserving existing relay selection and SASL password wiring.

### Testing
- Ran `bash -n rootfs/etc/cont-init.d/04-configure-postfix.sh` which returned without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d6e5f80e08320acf26488a3930bdb)