### PR TITLE
fix(security): prevent DKIM symlink ownership takeover

### DIFF
--- a/rootfs/etc/cont-init.d/02-dkim-setup.sh
+++ b/rootfs/etc/cont-init.d/02-dkim-setup.sh
@@ -25,9 +25,12 @@ echo -e "${CYAN}Checking DKIM keys...${NC}"
 # Ensure directory exists
 mkdir -p "${DKIM_DIR}"
 chmod 750 "${DKIM_DIR}"
-chown simplelogin:simplelogin "${DKIM_DIR}"
+chown root:simplelogin "${DKIM_DIR}"
 
-if [[ -f ${PRIVATE_KEY} ]]; then
+if [[ -L ${PRIVATE_KEY} ]]; then
+	echo -e "${RED}[ERROR] Refusing to use symlinked DKIM private key at ${PRIVATE_KEY}.${NC}"
+	exit 1
+elif [[ -f ${PRIVATE_KEY} ]]; then
 	echo -e "${GREEN}DKIM keys found at ${PRIVATE_KEY}. Skipping generation.${NC}"
 else
 	if [[ -z ${EMAIL_DOMAIN-} ]]; then
@@ -78,6 +81,10 @@ else
 	echo -e "A copy of this record has been saved to ${DNS_RECORD_FILE}"
 fi
 
+if [[ -L ${PRIVATE_KEY} ]]; then
+	echo -e "${RED}[ERROR] Refusing to update permissions on symlinked DKIM private key at ${PRIVATE_KEY}.${NC}"
+	exit 1
+fi
 chmod 600 "${PRIVATE_KEY}"
 chown simplelogin:simplelogin "${PRIVATE_KEY}"
 


### PR DESCRIPTION
### Motivation
- Close a symlink-following privilege-boundary bypass where the low-privileged `simplelogin` user could replace `/appdata/dkim/dkim.key` with a symlink and have root-owned init-time `chown/chmod` operate on the symlink target. 
- Preserve read access for the service while preventing the app user from replacing key files in-place. 
- Keep the runtime behavior compatible with the repository's non-root service model while restoring a safe ownership model for DKIM keys.

### Description
- Change ownership of the DKIM directory to `root:simplelogin` by making `chown root:simplelogin "${DKIM_DIR}"` so the app user cannot atomically replace key files in that directory. 
- Add an explicit symlink rejection check `if [[ -L ${PRIVATE_KEY} ]]; then ... exit 1` before treating the private key as an existing key to avoid accepting symlinked private keys. 
- Add a second symlink rejection guard immediately before final `chmod/chown` on the private key path to prevent dereferenced ownership/permission changes on restart. 

### Testing
- Ran `bash -n rootfs/etc/cont-init.d/02-dkim-setup.sh` to validate shell syntax and it succeeded. 
- Reviewed the diff of `rootfs/etc/cont-init.d/02-dkim-setup.sh` to confirm only DKIM path ownership and symlink-handling logic were changed and no unrelated functionality was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d8ae075dc8320bc8366af2ac2f51c)