### PR TITLE
fix(security): default registration to disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you want the simplest supported path:
 4. Leave dropdown-style advanced enum fields such as `ADMIN_FIDO_REQUIRED` on their documented values only. For most installs that means leaving `ADMIN_FIDO_REQUIRED=none`.
 5. Forward inbound TCP 25 from your router/firewall to the Unraid host.
 6. Start the container and wait for first-boot initialization to complete.
-7. Create your first account in the web UI with an existing personal mailbox that is not on `EMAIL_DOMAIN`, then disable registration in Advanced View if you want a private instance.
+7. Keep `DISABLE_REGISTRATION=true` (default) for a private instance. Only set it to `false` temporarily if you need web sign-up for first boot, then set it back to `true` and restart.
 8. Add the DNS records from [docs/simplelogin-setup.md](docs/simplelogin-setup.md).
 
 For most users, that is enough to get a working instance online.

--- a/docs/simplelogin-setup.md
+++ b/docs/simplelogin-setup.md
@@ -71,8 +71,8 @@ The wrapper now validates the rendered `.env` before starting the web app, job r
 After the container comes up:
 
 - open the web UI on port `7777`
-- create your first account in the web UI while registration is still enabled, using a personal mailbox that is not on `EMAIL_DOMAIN`
-- once your first account exists, set `DISABLE_REGISTRATION=true` in Advanced View and restart if you want a private instance
+- keep `DISABLE_REGISTRATION=true` (default) to prevent public sign-up
+- only set `DISABLE_REGISTRATION=false` temporarily if you need web sign-up for first boot; once your first account exists, set it back to `true` and restart
 - confirm `/health` responds
 - check the logs for any Postfix relay or DNS warnings
 - check `/appdata/sl` and `/appdata/postgres` were populated

--- a/simplelogin-aio.xml
+++ b/simplelogin-aio.xml
@@ -17,7 +17,7 @@
 [b]Quick Install (Beginners)[/b]&#xD;
 1. Install this template in Unraid.&#xD;
 2. Set [code]URL[/code], [code]EMAIL_DOMAIN[/code], [code]SUPPORT_EMAIL[/code], and [code]FLASK_SECRET[/code].&#xD;
-3. Leave registration enabled for first boot, create your first account with a mailbox that is not on [code]EMAIL_DOMAIN[/code], then disable registration later in Advanced View if you want a private instance.&#xD;
+3. Registration is disabled by default for safety. Temporarily set [code]DISABLE_REGISTRATION[/code] to [code]false[/code] only if you need web sign-up for first boot, then switch it back to [code]true[/code] and restart.&#xD;
 4. Choose an outbound relay mode if your ISP blocks outbound TCP 25.&#xD;
 5. Forward inbound TCP 25 from your router/firewall to the Unraid host if you want internet mail delivery.&#xD;
 6. Start the container, wait for first boot to finish, then add the required DNS records from the setup guide.&#xD;
@@ -105,7 +105,7 @@
   <Config Name="Partner API Token Secret" Target="PARTNER_API_TOKEN_SECRET" Default="" Mode="" Description="Optional partner token secret. Generate with: openssl rand -hex 32. Blank uses FLASK_SECRET." Type="Variable" Display="advanced" Required="false" Mask="true"/>
 
   <!-- Security and registration -->
-  <Config Name="Disable Registration" Target="DISABLE_REGISTRATION" Default="false|true" Mode="" Description="Leave false for first boot so you can create the first account. After that, switch to true and restart to close registration." Type="Variable" Display="advanced" Required="false" Mask="false">false</Config>
+  <Config Name="Disable Registration" Target="DISABLE_REGISTRATION" Default="true|false" Mode="" Description="Recommended default. Keep true to block public sign-up. Temporarily switch to false only while creating a first account, then set true again and restart." Type="Variable" Display="advanced" Required="false" Mask="false">true</Config>
   <Config Name="Disable Onboarding Emails" Target="DISABLE_ONBOARDING" Default="true|false" Mode="" Description="Recommended for self-hosted installs." Type="Variable" Display="advanced" Required="false" Mask="false">true</Config>
   <Config Name="Disable Alias Suffix" Target="DISABLE_ALIAS_SUFFIX" Default="true|false" Mode="" Description="Recommended for self-hosted installs to allow cleaner aliases without the random suffix." Type="Variable" Display="advanced" Required="false" Mask="false">true</Config>
   <Config Name="Enable SPF Enforcement" Target="ENFORCE_SPF" Default="true|false" Mode="" Description="Enable SPF enforcement using the extra headers provided by Postfix." Type="Variable" Display="advanced" Required="false" Mask="false">true</Config>


### PR DESCRIPTION
### Motivation
- Restore a safe default so internet-reachable installs do not start with public self-registration enabled due to the presence-style normalization of `DISABLE_REGISTRATION`.

### Description
- Change `DISABLE_REGISTRATION` to default to `true` in `simplelogin-aio.xml` and update the quick-install text in `simplelogin-aio.xml`, `README.md`, and `docs/simplelogin-setup.md` to document a closed-by-default posture with an explicit temporary `false` override for first-boot sign-up.

### Testing
- Verified occurrences and wording with a repository search (`rg -n "DISABLE_REGISTRATION|registration"`) and inspected the resulting XML/docs diffs, and the checks passed; no unit or integration test suite was executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d8ae5fb688320aaf09a6dcf0f8bc0)