### PR TITLE
fix(security): restrict simplelogin state dir permissions

### DIFF
--- a/rootfs/etc/cont-init.d/01-bootstrap-databases.sh
+++ b/rootfs/etc/cont-init.d/01-bootstrap-databases.sh
@@ -11,7 +11,7 @@ mkdir -p /appdata/postgres /appdata/redis /appdata/dkim /appdata/sl/upload /pgp 
 chown -R redis:redis /appdata/redis
 chown -R postgres:postgres /appdata/postgres /run/postgresql
 chown -R simplelogin:simplelogin /appdata/sl /pgp /custom-assets
-chmod 755 /appdata/sl
+chmod 700 /appdata/sl
 chmod 700 /appdata/postgres /appdata/redis /pgp
 chmod 700 /pgp
 


### PR DESCRIPTION
### Motivation
- Prevent world traversal/read of SimpleLogin state/upload data because the init script previously set `/appdata/sl` to `0755`, which can expose uploads to other local users or non-root service accounts.

### Description
- Change `chmod 755 /appdata/sl` to `chmod 700 /appdata/sl` in `rootfs/etc/cont-init.d/01-bootstrap-databases.sh` and keep directory creation, ownership, and the `/code/static/upload` symlink behavior unchanged.

### Testing
- Ran `bash -n rootfs/etc/cont-init.d/01-bootstrap-databases.sh` to verify syntax (success).
- Reviewed the resulting `git diff` to confirm only the permission hardening change was introduced (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d8bb7e8d0832090b1ddffd3f38e51)