### PR TITLE
fix: harden internal postgres auth defaults

### DIFF
--- a/rootfs/etc/cont-init.d/01-bootstrap-databases.sh
+++ b/rootfs/etc/cont-init.d/01-bootstrap-databases.sh
@@ -29,7 +29,7 @@ if [[ -z ${DB_URI_VALUE} ]]; then
 			echo "Unable to locate PostgreSQL binaries under /usr/lib/postgresql."
 			exit 1
 		fi
-		su -s /bin/bash postgres -c "${PG_BIN_DIR}/initdb -D /appdata/postgres"
+		su -s /bin/bash postgres -c "${PG_BIN_DIR}/initdb --auth-local=peer --auth-host=scram-sha-256 -D /appdata/postgres"
 
 		INTERNAL_PG_PASS=$(openssl rand -hex 24)
 		printf '%s\n' "${INTERNAL_PG_PASS}" >/appdata/postgres/.sl_internal_pass


### PR DESCRIPTION
### Motivation
- Prevent the internal PostgreSQL cluster from being initialized with the default `trust` rules so same-container processes cannot connect to the database over loopback/socket without authentication and potentially escalate to a PostgreSQL superuser.

### Description
- Update `rootfs/etc/cont-init.d/01-bootstrap-databases.sh` to invoke `initdb` with `--auth-local=peer --auth-host=scram-sha-256`, while preserving the existing generated internal password and `DB_URI` wiring.

### Testing
- Verified the new flags are present with `rg -n "initdb|auth-local|auth-host" rootfs/etc/cont-init.d/01-bootstrap-databases.sh` and committed the change; no automated test failures were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d8bb744dc8320acb7a055ba971140)