### PR TITLE
chore(release): v4.80.6-aio.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## v4.80.6-aio.3 - 2026-05-20
+
+### Fixes
+
+- Enforce verified TLS for SMTP relays
+
+- Prevent DKIM symlink ownership takeover
+
+- Harden internal Postgres auth defaults
+
+- Restrict SimpleLogin state dir permissions
+
+- Default registration to disabled
+
 ## v4.80.6-aio.2 - 2026-05-17
 
 ### Documentation

--- a/simplelogin-aio.xml
+++ b/simplelogin-aio.xml
@@ -31,9 +31,13 @@
 - Current upstream packaging is [code]linux/amd64[/code] only.&#xD;
 - This is still a real self-hosted mail stack. DNS, deliverability, router/firewall port forwarding, and sender reputation still matter.&#xD;
 - For the simplest operation, keep the internal Postgres/Redis/Postfix defaults and only set the small required config set above.</Overview>
-  <Changes>### 2026-05-17&#xD;
+  <Changes>### 2026-05-20&#xD;
 - Generated from CHANGELOG.md during release preparation. Do not edit manually.&#xD;
-- Clarify simplelogin registration mailbox</Changes>
+- Enforce verified TLS for SMTP relays&#xD;
+- Prevent DKIM symlink ownership takeover&#xD;
+- Harden internal Postgres auth defaults&#xD;
+- Restrict SimpleLogin state dir permissions&#xD;
+- Default registration to disabled</Changes>
   <Category>Network:Privacy Network:Web</Category>
   <WebUI>http://[IP]:[PORT:7777]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/simplelogin-aio.xml</TemplateURL>


### PR DESCRIPTION
## Summary
- Prepare the SimpleLogin AIO `v4.80.6-aio.3` release metadata after the security hardening closeout.

## What changed
- Added the `v4.80.6-aio.3` changelog section.
- Updated the Unraid template `<Changes>` block from the generated changelog notes.

## Why
- The merged SimpleLogin security fixes need a formal AIO release line and package publication.

## Validation
- `git diff --check`
- `python -m pytest tests/unit`
- `python -m aio_fleet validate-repo --repo simplelogin-aio --repo-path <repo>`
- `python -m aio_fleet release transaction --repo simplelogin-aio --sha <sha> --dry-run`
- `python -m aio_fleet registry verify --repo simplelogin-aio --sha <sha> --dry-run --verbose`

## Notes
- Registry dry-run includes `jsonbored/simplelogin-aio:v4.80.6-aio.3` and `ghcr.io/jsonbored/simplelogin-aio:v4.80.6-aio.3`.