### PR TITLE
chore(release): v4.80.6-aio.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## v4.80.6-aio.4 - 2026-05-26
+
+### Documentation
+
+- Add CA readme and utility category
+
 ## v4.80.6-aio.3 - 2026-05-20
 
 ### Fixes

--- a/simplelogin-aio.xml
+++ b/simplelogin-aio.xml
@@ -31,13 +31,9 @@
 - Current upstream packaging is [code]linux/amd64[/code] only.&#xD;
 - This is still a real self-hosted mail stack. DNS, deliverability, router/firewall port forwarding, and sender reputation still matter.&#xD;
 - For the simplest operation, keep the internal Postgres/Redis/Postfix defaults and only set the small required config set above.</Overview>
-  <Changes>### 2026-05-20&#xD;
+  <Changes>### 2026-05-26&#xD;
 - Generated from CHANGELOG.md during release preparation. Do not edit manually.&#xD;
-- Enforce verified TLS for SMTP relays&#xD;
-- Prevent DKIM symlink ownership takeover&#xD;
-- Harden internal Postgres auth defaults&#xD;
-- Restrict SimpleLogin state dir permissions&#xD;
-- Default registration to disabled</Changes>
+- Add CA readme and utility category</Changes>
   <Category>Network:Privacy Network:Web Tools:Utilities</Category>
   <WebUI>http://[IP]:[PORT:7777]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/simplelogin-aio.xml</TemplateURL>


### PR DESCRIPTION
## Summary
- Cut the v4.80.6-aio.4 release metadata.
- Update CHANGELOG.md and simplelogin-aio.xml <Changes> for the release.

## Validation
- `git diff --check`
- XML parse check for `simplelogin-aio.xml`
- `uv run --with pytest --with defusedxml python -m pytest -q tests/unit`
- commit hook: Trunk and fleet policy checks passed
