### PR TITLE
chore(release): v4.81.0-aio.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## v4.81.0-aio.1 - 2026-05-28
+
+### Maintenance
+
+- Bump simplelogin to v4.81.0
+
 ## v4.80.6-aio.4 - 2026-05-26
 
 ### Documentation

--- a/simplelogin-aio.xml
+++ b/simplelogin-aio.xml
@@ -31,9 +31,9 @@
 - Current upstream packaging is [code]linux/amd64[/code] only.&#xD;
 - This is still a real self-hosted mail stack. DNS, deliverability, router/firewall port forwarding, and sender reputation still matter.&#xD;
 - For the simplest operation, keep the internal Postgres/Redis/Postfix defaults and only set the small required config set above.</Overview>
-  <Changes>### 2026-05-26&#xD;
+  <Changes>### 2026-05-28&#xD;
 - Generated from CHANGELOG.md during release preparation. Do not edit manually.&#xD;
-- Add CA readme and utility category</Changes>
+- Bump simplelogin to v4.81.0</Changes>
   <Category>Network:Privacy Network:Web Tools:Utilities</Category>
   <WebUI>http://[IP]:[PORT:7777]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/simplelogin-aio.xml</TemplateURL>


### PR DESCRIPTION
## Summary
- Prepare the SimpleLogin AIO v4.81.0-aio.1 release metadata.

## What changed
- Add the v4.81.0-aio.1 changelog entry.
- Refresh the source XML <Changes> block from the changelog.

## Why
- The v4.81.0 upstream sync is merged and published, but formal release metadata was still missing.

## Validation
- git diff --check
- uv run --with pytest --with defusedxml pytest tests/unit -q