### PR TITLE
chore(release): v4.81.2-aio.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## v4.81.2-aio.1 - 2026-05-31
+
+### Maintenance
+
+- Bump simplelogin to v4.81.2
+
 ## v4.81.0-aio.1 - 2026-05-28
 
 ### Maintenance

--- a/simplelogin-aio.xml
+++ b/simplelogin-aio.xml
@@ -31,9 +31,9 @@
 - Current upstream packaging is [code]linux/amd64[/code] only.&#xD;
 - This is still a real self-hosted mail stack. DNS, deliverability, router/firewall port forwarding, and sender reputation still matter.&#xD;
 - For the simplest operation, keep the internal Postgres/Redis/Postfix defaults and only set the small required config set above.</Overview>
-  <Changes>### 2026-05-28&#xD;
+  <Changes>### 2026-05-31&#xD;
 - Generated from CHANGELOG.md during release preparation. Do not edit manually.&#xD;
-- Bump simplelogin to v4.81.0</Changes>
+- Bump simplelogin to v4.81.2</Changes>
   <Category>Network:Privacy Network:Web Tools:Utilities</Category>
   <WebUI>http://[IP]:[PORT:7777]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/simplelogin-aio.xml</TemplateURL>


### PR DESCRIPTION
## Summary
- Prepare the SimpleLogin v4.81.2-aio.1 release metadata.

## What changed
- Added the v4.81.2-aio.1 changelog entry.
- Updated the Unraid template Changes block from the generated changelog.

## Validation
- Fleet validate-repo passed.
- Fleet validate-template-common passed.
- git diff --check passed.