### PR TITLE
chore(release): v4.81.3-aio.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## v4.81.3-aio.1 - 2026-06-12
+
+### Maintenance
+
+- Refresh fleet manifest contract
+
+- Bump simplelogin to v4.81.3 (#95)
+
+### Tests
+
+- Use shared app test helpers
+
 ## v4.81.2-aio.1 - 2026-05-31
 
 ### Maintenance

--- a/simplelogin-aio.xml
+++ b/simplelogin-aio.xml
@@ -31,9 +31,11 @@
 - Current upstream packaging is [code]linux/amd64[/code] only.&#xD;
 - This is still a real self-hosted mail stack. DNS, deliverability, router/firewall port forwarding, and sender reputation still matter.&#xD;
 - For the simplest operation, keep the internal Postgres/Redis/Postfix defaults and only set the small required config set above.</Overview>
-  <Changes>### 2026-05-31&#xD;
+  <Changes>### 2026-06-12&#xD;
 - Generated from CHANGELOG.md during release preparation. Do not edit manually.&#xD;
-- Bump simplelogin to v4.81.2</Changes>
+- Refresh fleet manifest contract&#xD;
+- Bump simplelogin to v4.81.3 (#95)&#xD;
+- Use shared app test helpers</Changes>
   <Category>Network:Privacy Network:Web Tools:Utilities</Category>
   <WebUI>http://[IP]:[PORT:7777]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/simplelogin-aio.xml</TemplateURL>


### PR DESCRIPTION
Formal release of `simplelogin-aio` **v4.81.3-aio.1**. Adds CHANGELOG + Community Apps `<Changes>`; version/release tags + GitHub Release + catalog sync follow on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)